### PR TITLE
Remove is_null() calls and use require_once

### DIFF
--- a/src/Lit/Air/Factory.php
+++ b/src/Lit/Air/Factory.php
@@ -27,7 +27,7 @@ class Factory
     {
         if ($container instanceof Container) {
             $this->container = $container;
-        } elseif (is_null($container)) {
+        } elseif ($container === null) {
             $this->container = new Container();
         } else {
             $this->container = Container::wrap($container);

--- a/src/Lit/Air/Recipe/AutowireRecipe.php
+++ b/src/Lit/Air/Recipe/AutowireRecipe.php
@@ -27,8 +27,8 @@ class AutowireRecipe extends AbstractRecipe
 
     public function resolve(ContainerInterface $container, ?string $id = null)
     {
-        $className = is_null($this->className) ? $id : $this->className;
-        if (is_null($className) || !class_exists($className)) {
+        $className = $this->className ?? $id;
+        if ($className === null || !class_exists($className)) {
             throw new ContainerException('unknown autowire class name');
         }
 

--- a/src/Lit/Air/Recipe/InstanceRecipe.php
+++ b/src/Lit/Air/Recipe/InstanceRecipe.php
@@ -27,8 +27,8 @@ class InstanceRecipe extends AbstractRecipe
 
     public function resolve(ContainerInterface $container, ?string $id = null)
     {
-        $className = is_null($this->className) ? $id : $this->className;
-        if (is_null($className) || !class_exists($className)) {
+        $className = $this->className ?? $id;
+        if ($className === null || !class_exists($className)) {
             throw new ContainerException('unknown autowire class name');
         }
 

--- a/src/Lit/Bolt/Router/BoltStubResolver.php
+++ b/src/Lit/Bolt/Router/BoltStubResolver.php
@@ -36,7 +36,7 @@ class BoltStubResolver implements RouterStubResolverInterface
      */
     public function resolve($stub): RequestHandlerInterface
     {
-        if (is_null($stub) && $this->notFound) {
+        if ($stub === null && $this->notFound) {
             $stub = $this->notFound;
         }
 

--- a/src/Lit/Bolt/_example/hello_world.php
+++ b/src/Lit/Bolt/_example/hello_world.php
@@ -10,8 +10,8 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
 is_readable(__DIR__ . '/../vendor/autoload.php')
-    ? require(__DIR__ . '/../vendor/autoload.php')
-    : require(__DIR__ . '/../../../../vendor/autoload.php');
+    ? require_once __DIR__ . '/../vendor/autoload.php'
+    : require_once __DIR__ . '/../../../../vendor/autoload.php';
 
 class HelloAction extends BoltAbstractAction
 {

--- a/src/Lit/Bolt/_example/routing.php
+++ b/src/Lit/Bolt/_example/routing.php
@@ -8,8 +8,8 @@ use Lit\Runner\ZendSapi\BoltZendRunner;
 use Psr\Http\Message\ResponseInterface;
 
 is_readable(__DIR__ . '/../vendor/autoload.php')
-    ? require(__DIR__ . '/../vendor/autoload.php')
-    : require(__DIR__ . '/../../../../vendor/autoload.php');
+    ? require_once __DIR__ . '/../vendor/autoload.php'
+    : require_once __DIR__ . '/../../../../vendor/autoload.php';
 
 class ThrowResponseAction extends BoltAbstractAction
 {

--- a/src/Lit/Voltage/_example/hello_world.php
+++ b/src/Lit/Voltage/_example/hello_world.php
@@ -10,7 +10,7 @@ use Zend\HttpHandlerRunner\Emitter\SapiEmitter;
 // @codeCoverageIgnoreStart
 
 /** @noinspection PhpIncludeInspection */
-require(__DIR__ . '/../vendor/autoload.php');
+require_once __DIR__ . '/../vendor/autoload.php';
 
 class HelloAction extends AbstractAction
 {


### PR DESCRIPTION
* Change is_null() in "=== null" to be consistant with "!== null" in
codebase (as a bonus, it's faster (no function call))
* Use require_once instead of require (also marginally faster)
* Remove parenthesis from require_once calls, as it's a language
construct
* Use null coalescing operator to improve readability