### PR TITLE
Feature/docblocks

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,6 +7,8 @@
     <rule ref="PSR1"/>
     <rule ref="PSR2"/>
     <rule ref="PSR12"/>
+    <rule ref="Squiz.Commenting.ClassComment"/>
+    <rule ref="Squiz.Commenting.FunctionComment"/>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array" value="sizeof=>count,delete=>unset,require=>require_once,print=>echo,is_null=>null,create_function=>null"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -7,10 +7,6 @@
     <rule ref="PSR1"/>
     <rule ref="PSR2"/>
     <rule ref="PSR12"/>
-    <rule ref="Squiz.Commenting.ClassComment"/>
-    <rule ref="Squiz.Commenting.FunctionComment">
-        <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
-    </rule>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array" value="sizeof=>count,delete=>unset,require=>require_once,print=>echo,is_null=>null,create_function=>null"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,13 +2,15 @@
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/3.3.1/phpcs.xsd">
     <file>./src/</file>
-    <exclude-pattern>./src/**/Test/*</exclude-pattern>
+    <exclude-pattern>./src/**/Tests/*</exclude-pattern>
     <exclude-pattern>./vendor/*</exclude-pattern>
     <rule ref="PSR1"/>
     <rule ref="PSR2"/>
     <rule ref="PSR12"/>
     <rule ref="Squiz.Commenting.ClassComment"/>
-    <rule ref="Squiz.Commenting.FunctionComment"/>
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <exclude name="Squiz.Commenting.FunctionComment.Missing"/>
+    </rule>
     <rule ref="Generic.PHP.ForbiddenFunctions">
         <properties>
             <property name="forbiddenFunctions" type="array" value="sizeof=>count,delete=>unset,require=>require_once,print=>echo,is_null=>null,create_function=>null"/>

--- a/src/Lit/Air/Configurator.php
+++ b/src/Lit/Air/Configurator.php
@@ -13,6 +13,10 @@ use Lit\Air\Recipe\Decorator\SingletonDecorator;
 use Lit\Air\Recipe\FixedValueRecipe;
 use Lit\Air\Recipe\RecipeInterface;
 
+/**
+ * Configurator helps to build an array configuration, and writes array configuration into a container.
+ * http://litphp.github.io/docs/air-config
+ */
 class Configurator
 {
     protected static $decorators = [
@@ -20,6 +24,14 @@ class Configurator
         'singleton' => SingletonDecorator::class,
     ];
 
+    /**
+     * Write a configuration array into a container
+     *
+     * @param Container $container The container.
+     * @param array     $config    The configuration array.
+     * @param boolean   $force     Whether overwrite existing values.
+     * @return void
+     */
     public static function config(Container $container, array $config, bool $force = true): void
     {
         foreach ($config as $key => $value) {
@@ -30,6 +42,12 @@ class Configurator
         }
     }
 
+    /**
+     * Convert a mixed value into a recipe.
+     *
+     * @param mixed $value The value.
+     * @return RecipeInterface
+     */
     public static function convertToRecipe($value): RecipeInterface
     {
         if (is_object($value) && $value instanceof RecipeInterface) {
@@ -47,11 +65,24 @@ class Configurator
         return Container::value($value);
     }
 
+    /**
+     * Configuration indicating a singleton
+     *
+     * @param string $classname The class name.
+     * @param array  $extra     Extra parameters.
+     * @return array
+     */
     public static function singleton(string $classname, array $extra = []): array
     {
         return self::decorateSingleton(self::instance($classname, $extra));
     }
 
+    /**
+     * Decorate a configuration, makes it a singleton (\Lit\Air\Recipe\Decorator\SingletonDecorator)
+     *
+     * @param array $config The configuration.
+     * @return array
+     */
     public static function decorateSingleton(array $config): array
     {
         $config['decorator'] = $config['decorator'] ?? [];
@@ -60,6 +91,13 @@ class Configurator
         return $config;
     }
 
+    /**
+     * Decorate a configuration with provided callback
+     *
+     * @param array    $config   The configuration.
+     * @param callable $callback The callback.
+     * @return array
+     */
     public static function decorateCallback(array $config, callable $callback): array
     {
         $config['decorator'] = $config['decorator'] ?? [];
@@ -68,6 +106,12 @@ class Configurator
         return $config;
     }
 
+    /**
+     * Provide extra parameter for autowired entry. The key should be a valid class name.
+     *
+     * @param array $extra Extra parameters.
+     * @return array
+     */
     public static function provideParameter(array $extra = []): array
     {
         return [
@@ -77,6 +121,13 @@ class Configurator
         ];
     }
 
+    /**
+     * Configuration indicating an autowired entry.
+     *
+     * @param string|null $classname The class name. Can be ignored but better use `provideParameter` in that case.
+     * @param array       $extra     Extra parameters.
+     * @return array
+     */
     public static function produce(?string $classname, array $extra = []): array
     {
         return [
@@ -86,6 +137,13 @@ class Configurator
         ];
     }
 
+    /**
+     * Configuration indicating an instance created by factory.
+     *
+     * @param string $classname The class name.
+     * @param array  $extra     Extra parameters.
+     * @return array
+     */
     public static function instance(string $classname, array $extra = []): array
     {
         return [
@@ -95,6 +153,12 @@ class Configurator
         ];
     }
 
+    /**
+     * Configuration indicating an alias
+     *
+     * @param string ...$key Multiple keys will be auto joined.
+     * @return array
+     */
     public static function alias(string... $key): array
     {
         return [
@@ -103,15 +167,28 @@ class Configurator
         ];
     }
 
+    /**
+     * Configuration wrapping a builder method
+     *
+     * @param callable $builder The builder method.
+     * @param array    $extra   Extra parameters.
+     * @return array
+     */
     public static function builder(callable $builder, array $extra = []): array
     {
         return [
             '$' => 'builder',
             $builder,
-            $extra
+            $extra,
         ];
     }
 
+    /**
+     * Configuration wraps an arbitary value. For arrays it's recommended to always wrap with this.
+     *
+     * @param mixed $value The value.
+     * @return array
+     */
     public static function value($value): array
     {
         return [
@@ -144,10 +221,6 @@ class Configurator
         }
     }
 
-    /**
-     * @param array $value
-     * @return array
-     */
     protected static function convertArray(array $value): array
     {
         $result = [];
@@ -194,8 +267,10 @@ class Configurator
     }
 
     /**
-     * @param array           $decorators
-     * @param RecipeInterface $recipe
+     * Apply decorators to a recipe and return the decorated recipe
+     *
+     * @param array           $decorators Assoc array of decorator names => options.
+     * @param RecipeInterface $recipe     The decorated recipe instance.
      * @return RecipeInterface
      */
     public static function wrapRecipeWithDecorators(array $decorators, RecipeInterface $recipe): RecipeInterface
@@ -222,6 +297,12 @@ class Configurator
         return $recipe;
     }
 
+    /**
+     * Join multiple strings with air conventional separator `::`
+     *
+     * @param string ...$args Parts of the key to be joined.
+     * @return string
+     */
     public static function join(string... $args): string
     {
         return implode('::', $args);

--- a/src/Lit/Air/Configurator.php
+++ b/src/Lit/Air/Configurator.php
@@ -194,7 +194,7 @@ class Configurator
     }
 
     /**
-     * @param array $decorators
+     * @param array           $decorators
      * @param RecipeInterface $recipe
      * @return RecipeInterface
      */

--- a/src/Lit/Air/Factory.php
+++ b/src/Lit/Air/Factory.php
@@ -46,7 +46,7 @@ class Factory
 
     /**
      * @param string $className
-     * @param array $extraParameters
+     * @param array  $extraParameters
      * @return object
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \ReflectionException
@@ -68,7 +68,7 @@ class Factory
 
     /**
      * @param callable $callback
-     * @param array $extra
+     * @param array    $extra
      * @return mixed
      * @throws \ReflectionException
      */
@@ -102,7 +102,7 @@ class Factory
 
     /**
      * @param string $className
-     * @param array $extraParameters
+     * @param array  $extraParameters
      * @return object of $className«
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \ReflectionException
@@ -156,7 +156,7 @@ class Factory
 
     /**
      * @param object $obj
-     * @param array $extra
+     * @param array  $extra
      * @throws \Psr\Container\ContainerExceptionInterface
      */
     public function inject($obj, array $extra = []): void
@@ -175,10 +175,10 @@ class Factory
     }
 
     /**
-     * @param string $basename
-     * @param array $keys
+     * @param string      $basename
+     * @param array       $keys
      * @param null|string $className
-     * @param array $extra
+     * @param array       $extra
      * @return mixed|object
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \ReflectionException
@@ -216,8 +216,8 @@ class Factory
 
     /**
      * @param string $basename
-     * @param array $keys
-     * @param array $extra
+     * @param array  $keys
+     * @param array  $extra
      * @return array|null
      * @throws \Psr\Container\ContainerExceptionInterface
      */
@@ -262,9 +262,9 @@ class Factory
     }
 
     /**
-     * @param string $basename
+     * @param string               $basename
      * @param \ReflectionParameter $parameter
-     * @param array $extraParameters
+     * @param array                $extraParameters
      * @return mixed|object
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \ReflectionException

--- a/src/Lit/Air/Injection/InjectorInterface.php
+++ b/src/Lit/Air/Injection/InjectorInterface.php
@@ -6,9 +6,26 @@ namespace Lit\Air\Injection;
 
 use Lit\Air\Factory;
 
+/**
+ * InjectorInterface represents a injector, which is a policy of DI injection other than constructor injection.
+ */
 interface InjectorInterface
 {
+    /**
+     * Decide whether provided object is target of this injector.
+     *
+     * @param object $obj The object to be checked.
+     * @return boolean
+     */
     public function isTarget($obj): bool;
 
+    /**
+     * Do the injection process.
+     *
+     * @param Factory $factory The factory.
+     * @param object  $obj     The Object.
+     * @param array   $extra   Extra parameters.
+     * @return void
+     */
     public function inject(Factory $factory, $obj, array $extra = []): void;
 }

--- a/src/Lit/Air/Injection/SetterInjector.php
+++ b/src/Lit/Air/Injection/SetterInjector.php
@@ -8,13 +8,18 @@ use Lit\Air\Factory;
 use Lit\Air\Psr\ContainerException;
 use ReflectionMethod;
 
+/**
+ * SetterInjector inject dependencies into an object by it's setter method.
+ * By default only method with name injectXXX and with single parameter will be considered.
+ */
 class SetterInjector implements InjectorInterface
 {
     protected $prefixes = ['inject'];
 
     /**
      * SetterInjector constructor.
-     * @param array|string[] $prefixes
+     *
+     * @param array|string[] $prefixes Method prefix(es) to scan.
      */
     public function __construct(array $prefixes = ['inject'])
     {
@@ -51,11 +56,6 @@ class SetterInjector implements InjectorInterface
         return defined("$class::SETTER_INJECTOR") && $class::SETTER_INJECTOR === static::class;
     }
 
-    /**
-     *
-     * @param array $prefixes
-     * @return $this
-     */
     public function setPrefixes(array $prefixes): self
     {
         $this->prefixes = $prefixes;
@@ -81,6 +81,11 @@ class SetterInjector implements InjectorInterface
         return false;
     }
 
+    /**
+     * Configuration method of setter injector.
+     *
+     * @return array
+     */
     public static function configuration()
     {
         return [

--- a/src/Lit/Air/Psr/CircularDependencyException.php
+++ b/src/Lit/Air/Psr/CircularDependencyException.php
@@ -6,6 +6,9 @@ namespace Lit\Air\Psr;
 
 use Throwable;
 
+/**
+ * Failure when there's a circular dependency.
+ */
 class CircularDependencyException extends ContainerException
 {
     /**

--- a/src/Lit/Air/Psr/Container.php
+++ b/src/Lit/Air/Psr/Container.php
@@ -168,7 +168,7 @@ class Container implements ContainerInterface
     }
 
     /**
-     * @param callable $wrapper
+     * @param callable        $wrapper
      * @param RecipeInterface $recipe
      * @return RecipeInterface
      */

--- a/src/Lit/Air/Psr/Container.php
+++ b/src/Lit/Air/Psr/Container.php
@@ -14,6 +14,9 @@ use Lit\Air\Recipe\InstanceRecipe;
 use Lit\Air\Recipe\RecipeInterface;
 use Psr\Container\ContainerInterface;
 
+/**
+ * Air DI container
+ */
 class Container implements ContainerInterface
 {
     const CONFIGURATOR_CLASS = Configurator::class;
@@ -28,6 +31,11 @@ class Container implements ContainerInterface
      */
     protected $delegateContainer;
 
+    /**
+     * Container constructor.
+     *
+     * @param array|null $config Configuration array. See `Configurator` for more details.
+     */
     public function __construct(?array $config = null)
     {
         if ($config) {
@@ -42,41 +50,75 @@ class Container implements ContainerInterface
         $this->set(ContainerInterface::class, $this);
     }
 
+    /**
+     * Create a alias
+     *
+     * @param string $alias The alias string key.
+     * @return AbstractRecipe
+     */
     public static function alias(string $alias): AbstractRecipe
     {
         return new AliasRecipe($alias);
     }
 
+    /**
+     * Autowire this entry
+     *
+     * @param string|null $className Optional classname. Can be ommited when the entry key is the classname.
+     * @param array       $extra     Extra parameteres.
+     * @return AbstractRecipe
+     */
     public static function autowire(?string $className = null, array $extra = []): AbstractRecipe
     {
         return new AutowireRecipe($className, $extra);
     }
 
+    /**
+     * Populate an instance by factory
+     *
+     * @param string|null $className Optional classname. Can be ommited when the entry key is the classname.
+     * @param array       $extra     Extra parameteres.
+     * @return AbstractRecipe
+     */
     public static function instance(?string $className = null, array $extra = []): AbstractRecipe
     {
         return new InstanceRecipe($className, $extra);
     }
 
+    /**
+     * Calls a builder method using factory.
+     *
+     * @param callable $builder The builder method. Its parameter will be injected as dependency.
+     * @param array    $extra   Extra parameters.
+     * @return AbstractRecipe
+     */
     public static function builder(callable $builder, array $extra = []): AbstractRecipe
     {
         return new BuilderRecipe($builder, $extra);
     }
 
+    /**
+     * A fixed value
+     *
+     * @param mixed $value The value.
+     * @return AbstractRecipe
+     */
     public static function value($value): AbstractRecipe
     {
         return new FixedValueRecipe($value);
     }
 
+    /**
+     * Wraps a PSR container
+     *
+     * @param ContainerInterface $container The container.
+     * @return Container
+     */
     public static function wrap(ContainerInterface $container): self
     {
         return (new static())->setDelegateContainer($container);
     }
 
-    /**
-     * @param string $id
-     * @return mixed
-     * @throws \Psr\Container\ContainerExceptionInterface
-     */
     public function get($id)
     {
         if (array_key_exists($id, $this->local)) {
@@ -101,12 +143,25 @@ class Container implements ContainerInterface
             || ($this->delegateContainer && $this->delegateContainer->has($id));
     }
 
+    /**
+     * Set a recipe to given id
+     *
+     * @param string          $id     The key.
+     * @param RecipeInterface $recipe The recipe instance.
+     * @return Container
+     */
     public function define(string $id, RecipeInterface $recipe): self
     {
         $this->recipe[$id] = $recipe;
         return $this;
     }
 
+    /**
+     * Get recipe instance from the id
+     *
+     * @param string $id The key.
+     * @return RecipeInterface|null
+     */
     public function getRecipe(string $id): ?RecipeInterface
     {
         if (array_key_exists($id, $this->recipe)) {
@@ -116,6 +171,13 @@ class Container implements ContainerInterface
         return null;
     }
 
+    /**
+     * Get a recipe from the id, wrap a new recipe to replace it.
+     *
+     * @param string   $id      The key.
+     * @param callable $wrapper A recipe wrapper with signature (RecipeInterface): RecipeInterface.
+     * @return Container
+     */
     public function extendRecipe(string $id, callable $wrapper): self
     {
         if (!array_key_exists($id, $this->recipe)) {
@@ -129,17 +191,36 @@ class Container implements ContainerInterface
         return $this;
     }
 
+    /**
+     * Detect if there is a local entry for id
+     *
+     * @param string $id The key.
+     * @return boolean
+     */
     public function hasLocalEntry(string $id): bool
     {
         return array_key_exists($id, $this->local);
     }
 
+    /**
+     * Remove the local entry in id. Note this will never touch recipe.
+     *
+     * @param string $id The key.
+     * @return Container
+     */
     public function flush(string $id): self
     {
         unset($this->local[$id]);
         return $this;
     }
 
+    /**
+     * Convert a value into recipe and resolve it. See
+     * http://litphp.github.io/docs/air-config#structure-of-configuration
+     *
+     * @param mixed $value The value.
+     * @return mixed
+     */
     public function resolveRecipe($value)
     {
         $class = static::CONFIGURATOR_CLASS;
@@ -150,14 +231,24 @@ class Container implements ContainerInterface
         return $class::convertToRecipe($value)->resolve($this);
     }
 
-    public function set($id, $value): self
+    /**
+     * Set a local entry
+     *
+     * @param string $id    The key.
+     * @param mixed  $value The Value.
+     * @return Container
+     */
+    public function set(string $id, $value): self
     {
         $this->local[$id] = $value;
         return $this;
     }
 
     /**
-     * @param ContainerInterface $delegateContainer
+     * Set a delegate container.
+     * https://github.com/container-interop/container-interop/blob/HEAD/docs/Delegate-lookup.md
+     *
+     * @param ContainerInterface $delegateContainer The delegate container.
      * @return $this
      */
     public function setDelegateContainer(ContainerInterface $delegateContainer): self
@@ -167,11 +258,6 @@ class Container implements ContainerInterface
         return $this;
     }
 
-    /**
-     * @param callable        $wrapper
-     * @param RecipeInterface $recipe
-     * @return RecipeInterface
-     */
     protected static function applyRecipeWrapper(callable $wrapper, RecipeInterface $recipe): RecipeInterface
     {
         $recipe = $wrapper($recipe);

--- a/src/Lit/Air/Psr/ContainerException.php
+++ b/src/Lit/Air/Psr/ContainerException.php
@@ -6,6 +6,9 @@ namespace Lit\Air\Psr;
 
 use Psr\Container\ContainerExceptionInterface;
 
+/**
+ * Concrete ContainerExceptionInterface.
+ */
 class ContainerException extends \LogicException implements ContainerExceptionInterface
 {
 

--- a/src/Lit/Air/Psr/NotFoundException.php
+++ b/src/Lit/Air/Psr/NotFoundException.php
@@ -6,6 +6,9 @@ namespace Lit\Air\Psr;
 
 use Psr\Container\NotFoundExceptionInterface;
 
+/**
+ * Concrete NotFoundExceptionInterface
+ */
 class NotFoundException extends ContainerException implements NotFoundExceptionInterface
 {
 

--- a/src/Lit/Air/Recipe/AbstractRecipe.php
+++ b/src/Lit/Air/Recipe/AbstractRecipe.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lit\Air\Recipe;
 
+/**
+ * Base class of recipe
+ */
 abstract class AbstractRecipe implements RecipeInterface
 {
     use RecipeTrait;

--- a/src/Lit/Air/Recipe/AliasRecipe.php
+++ b/src/Lit/Air/Recipe/AliasRecipe.php
@@ -6,6 +6,9 @@ namespace Lit\Air\Recipe;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * Get from another key when this recipe resolves.
+ */
 class AliasRecipe extends AbstractRecipe
 {
     /**
@@ -13,9 +16,6 @@ class AliasRecipe extends AbstractRecipe
      */
     protected $alias;
 
-    /**
-     * @param string $alias
-     */
     public function __construct(string $alias)
     {
         $this->alias = $alias;

--- a/src/Lit/Air/Recipe/AutowireRecipe.php
+++ b/src/Lit/Air/Recipe/AutowireRecipe.php
@@ -8,6 +8,12 @@ use Lit\Air\Factory;
 use Lit\Air\Psr\ContainerException;
 use Psr\Container\ContainerInterface;
 
+/**
+ * Recipe that calls $factory->produce to resolve. a.k.a autowire.
+ *
+ * Since `produce` method will save the product under `$className` key in container and reuse it, it's singleton. If
+ * you need multiple instance, use `InstanceRecipe` instead.
+ */
 class AutowireRecipe extends AbstractRecipe
 {
     /**

--- a/src/Lit/Air/Recipe/BuilderRecipe.php
+++ b/src/Lit/Air/Recipe/BuilderRecipe.php
@@ -7,6 +7,9 @@ namespace Lit\Air\Recipe;
 use Lit\Air\Factory;
 use Psr\Container\ContainerInterface;
 
+/**
+ * Calls a builder method when resolved. The "builder method" will be invoked by $factory->invoke
+ */
 class BuilderRecipe extends AbstractRecipe
 {
     /**
@@ -18,11 +21,6 @@ class BuilderRecipe extends AbstractRecipe
      */
     protected $extra;
 
-    /**
-     * MultitonStub constructor.
-     * @param callable $builder
-     * @param array    $extra
-     */
     public function __construct(callable $builder, array $extra = [])
     {
         $this->builder = $builder;

--- a/src/Lit/Air/Recipe/BuilderRecipe.php
+++ b/src/Lit/Air/Recipe/BuilderRecipe.php
@@ -21,7 +21,7 @@ class BuilderRecipe extends AbstractRecipe
     /**
      * MultitonStub constructor.
      * @param callable $builder
-     * @param array $extra
+     * @param array    $extra
      */
     public function __construct(callable $builder, array $extra = [])
     {

--- a/src/Lit/Air/Recipe/Decorator/AbstractRecipeDecorator.php
+++ b/src/Lit/Air/Recipe/Decorator/AbstractRecipeDecorator.php
@@ -7,6 +7,9 @@ namespace Lit\Air\Recipe\Decorator;
 use Lit\Air\Recipe\RecipeInterface;
 use Lit\Air\Recipe\RecipeTrait;
 
+/**
+ * Decorator or wrapper recipe which change another recipe's behavior
+ */
 abstract class AbstractRecipeDecorator implements RecipeInterface
 {
     use RecipeTrait;
@@ -21,13 +24,21 @@ abstract class AbstractRecipeDecorator implements RecipeInterface
         $this->recipe = $recipe;
     }
 
+    /**
+     * Decorates provided recipe.
+     *
+     * @param RecipeInterface $recipe The inner recipe.
+     * @return AbstractRecipeDecorator A new recipe with decorated behavior
+     */
     public static function decorate(RecipeInterface $recipe): self
     {
         return new static($recipe);
     }
 
     /**
-     * @param mixed $option
+     * Option setter
+     *
+     * @param mixed $option The option value.
      * @return AbstractRecipeDecorator
      */
     public function setOption($option): self

--- a/src/Lit/Air/Recipe/Decorator/CallbackDecorator.php
+++ b/src/Lit/Air/Recipe/Decorator/CallbackDecorator.php
@@ -6,6 +6,9 @@ namespace Lit\Air\Recipe\Decorator;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * Dynamic decorator that calls a callback (option value)
+ */
 class CallbackDecorator extends AbstractRecipeDecorator
 {
     public function resolve(ContainerInterface $container, ?string $id = null)

--- a/src/Lit/Air/Recipe/Decorator/SingletonDecorator.php
+++ b/src/Lit/Air/Recipe/Decorator/SingletonDecorator.php
@@ -6,6 +6,9 @@ namespace Lit\Air\Recipe\Decorator;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * Turns a recipe into a singleton. When it's resolved once, the value will be cached and reused.
+ */
 class SingletonDecorator extends AbstractRecipeDecorator
 {
     protected $value;

--- a/src/Lit/Air/Recipe/FixedValueRecipe.php
+++ b/src/Lit/Air/Recipe/FixedValueRecipe.php
@@ -6,6 +6,9 @@ namespace Lit\Air\Recipe;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * Always return a fixed value. Useful for test, and as a wrapper of arbitary value.
+ */
 class FixedValueRecipe extends AbstractRecipe
 {
     protected $value;

--- a/src/Lit/Air/Recipe/InstanceRecipe.php
+++ b/src/Lit/Air/Recipe/InstanceRecipe.php
@@ -8,6 +8,12 @@ use Lit\Air\Factory;
 use Lit\Air\Psr\ContainerException;
 use Psr\Container\ContainerInterface;
 
+/**
+ * Recipe that calls $container->instantiate to resolve.
+ *
+ * Since `instantiate` method only create instance, so this recipe will create multiple instance when resolved multiple
+ * times. Can be decorated by SingletonDecorator to makes it a singleton.
+ */
 class InstanceRecipe extends AbstractRecipe
 {
     /**

--- a/src/Lit/Air/Recipe/RecipeInterface.php
+++ b/src/Lit/Air/Recipe/RecipeInterface.php
@@ -6,7 +6,19 @@ namespace Lit\Air\Recipe;
 
 use Psr\Container\ContainerInterface;
 
+/**
+ * RecipeInterface represents a dynamic entry in container. When the entry is fetched, the resolve method is invoked to
+ * provide the concrete value.
+ */
 interface RecipeInterface
 {
+    /**
+     * Provide the concrete value
+     *
+     * @param ContainerInterface $container The container object.
+     * @param string|null        $id        The key used to fetch, might be null when this recipe is not attached
+     *                                      directly in container.
+     * @return mixed The concrete value.
+     */
     public function resolve(ContainerInterface $container, ?string $id = null);
 }

--- a/src/Lit/Air/Recipe/RecipeTrait.php
+++ b/src/Lit/Air/Recipe/RecipeTrait.php
@@ -7,6 +7,9 @@ namespace Lit\Air\Recipe;
 use Lit\Air\Recipe\Decorator\CallbackDecorator;
 use Lit\Air\Recipe\Decorator\SingletonDecorator;
 
+/**
+ * RecipeTrait provides some wrapping method to a recipe object.
+ */
 trait RecipeTrait
 {
     public function singleton(): RecipeInterface

--- a/src/Lit/Air/Tests/AirTestCase.php
+++ b/src/Lit/Air/Tests/AirTestCase.php
@@ -51,7 +51,7 @@ abstract class AirTestCase extends TestCase
 
     /**
      * @param string $key
-     * @param mixed $obj
+     * @param mixed  $obj
      */
     protected function assertKeyExistWithValue(string $key, $obj): void
     {

--- a/src/Lit/Bolt/BoltAbstractAction.php
+++ b/src/Lit/Bolt/BoltAbstractAction.php
@@ -10,13 +10,19 @@ use Lit\Bolt\Middlewares\RequestContext;
 use Lit\Voltage\AbstractAction;
 use Psr\Http\Message\ResponseFactoryInterface;
 
+/**
+ * Base action class for bolt
+ *
+ * It's strongly recommended to have your own action base class extending this one
+ */
 abstract class BoltAbstractAction extends AbstractAction
 {
     const SETTER_INJECTOR = SetterInjector::class;
 
     /**
+     * Injector for ResponseFactory
      *
-     * @param ResponseFactoryInterface $responseFactory
+     * @param ResponseFactoryInterface $responseFactory The ResponseFactory.
      * @return $this
      */
     public function injectResponseFactory(ResponseFactoryInterface $responseFactory): BoltAbstractAction

--- a/src/Lit/Bolt/BoltApp.php
+++ b/src/Lit/Bolt/BoltApp.php
@@ -12,6 +12,9 @@ use Lit\Voltage\App;
 use Lit\Voltage\Interfaces\ThrowableResponseInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Bolt application
+ */
 class BoltApp extends App
 {
     const SETTER_INJECTOR = SetterInjector::class;
@@ -24,12 +27,24 @@ class BoltApp extends App
      */
     protected $requestContext;
 
+    /**
+     * Injector for EventsHub
+     *
+     * @param EventsHub|null $eventsHub The EventsHub.
+     * @return $this
+     */
     public function injectEventsHub(?EventsHub $eventsHub)
     {
         $this->eventsHub = $eventsHub;
         return $this;
     }
 
+    /**
+     * Injector for RequestContext
+     *
+     * @param RequestContext|null $requestContext The RequestContext.
+     * @return $this
+     */
     public function injectRequestContext(?RequestContext $requestContext)
     {
         $this->requestContext = $requestContext;
@@ -37,6 +52,8 @@ class BoltApp extends App
     }
 
     /**
+     * Getter for EventsHub
+     *
      * @return EventsHub
      */
     public function getEventsHub(): EventsHub

--- a/src/Lit/Bolt/BoltContainerConfiguration.php
+++ b/src/Lit/Bolt/BoltContainerConfiguration.php
@@ -7,13 +7,27 @@ namespace Lit\Bolt;
 use Lit\Air\Injection\SetterInjector;
 use Lit\Air\Psr\Container;
 
+/**
+ * Configuration class for Bolt
+ */
 class BoltContainerConfiguration
 {
+    /**
+     * Configuration for Bolt.
+     *
+     * @return array
+     */
     public static function default()
     {
         return SetterInjector::configuration();
     }
 
+    /**
+     * Create a container instance.
+     *
+     * @param array $config The configuration array.
+     * @return Container
+     */
     public static function createContainer(array $config = []): Container
     {
         return new Container($config + static::default());

--- a/src/Lit/Bolt/BoltEvent.php
+++ b/src/Lit/Bolt/BoltEvent.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Lit\Bolt;
 
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
- * Class BoltEvent
- * @package Lit\Bolt
+ * Event class for Bolt
  *
  * @method MiddlewareInterface getSubject()
  */
@@ -20,6 +19,13 @@ class BoltEvent extends GenericEvent
     const EVENT_BEFORE_LOGIC = 'bolt.before_logic';
     const EVENT_AFTER_LOGIC = 'bolt.after_logic';
 
+    /**
+     * Create a new bolt event
+     *
+     * @param MiddlewareInterface $middleware The subject middleware.
+     * @param array               $arguments  Event arguments.
+     * @return BoltEvent
+     */
     public static function of(MiddlewareInterface $middleware, array $arguments = [])
     {
         return new static($middleware, $arguments);
@@ -30,7 +36,7 @@ class BoltEvent extends GenericEvent
         return $this['response'] ?? null;
     }
 
-    public function getRequest(): ?RequestInterface
+    public function getRequest(): ?ServerRequestInterface
     {
         return $this['request'] ?? null;
     }

--- a/src/Lit/Bolt/Middlewares/EventsHub.php
+++ b/src/Lit/Bolt/Middlewares/EventsHub.php
@@ -10,6 +10,9 @@ use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
+/**
+ * Middleware for pub-sub pattern
+ */
 class EventsHub extends AbstractMiddleware
 {
     /**

--- a/src/Lit/Bolt/Middlewares/RequestContext.php
+++ b/src/Lit/Bolt/Middlewares/RequestContext.php
@@ -10,6 +10,10 @@ use Lit\Nimo\Traits\MiddlewareTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
 
+/**
+ * Subclass of SPL ArrayObject that can attach to a PSR request as middleware.
+ * Useful the store arbitary context without polluting request attributes.
+ */
 class RequestContext extends \ArrayObject implements MiddlewareInterface
 {
     use MiddlewareTrait;

--- a/src/Lit/Bolt/Router/BoltContainerStub.php
+++ b/src/Lit/Bolt/Router/BoltContainerStub.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace Lit\Bolt\Router;
 
 use Lit\Air\Factory;
+use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 
+/**
+ * Helper class for resolving stub with container
+ */
 class BoltContainerStub
 {
     /**
@@ -18,17 +22,36 @@ class BoltContainerStub
      */
     protected $extraParameters;
 
+    /**
+     * BoltContainerStub constructor.
+     *
+     * @param string $className       Name of the class.
+     * @param array  $extraParameters Extra params fed into DI factory.
+     */
     public function __construct(string $className, array $extraParameters = [])
     {
         $this->className = $className;
         $this->extraParameters = $extraParameters;
     }
 
+    /**
+     * Shortcut method of constructor.
+     *
+     * @param string $className       Name of the class.
+     * @param array  $extraParameters Extra params fed into DI factory.
+     * @return BoltContainerStub
+     */
     public static function of(string $className, array $extraParameters = []): self
     {
         return new static($className, $extraParameters);
     }
 
+    /**
+     * Try to parse the stub
+     *
+     * @param mixed $stub The stub.
+     * @return BoltContainerStub|null
+     */
     public static function tryParse($stub): ?self
     {
         if (is_string($stub) && class_exists($stub)) {
@@ -43,7 +66,16 @@ class BoltContainerStub
         return null;
     }
 
-    public function instantiateFrom(ContainerInterface $container, $extraParameters = [])
+    /**
+     * Populate concrete product from given container
+     *
+     * @param ContainerInterface $container       The container.
+     * @param array              $extraParameters Extra parameters.
+     * @return object
+     * @throws ContainerExceptionInterface Failed to produce.
+     * @throws \ReflectionException Failed to produce.
+     */
+    public function instantiateFrom(ContainerInterface $container, array $extraParameters = [])
     {
         return Factory::of($container)->instantiate($this->className, $extraParameters + $this->extraParameters);
     }

--- a/src/Lit/Bolt/Router/BoltStubResolver.php
+++ b/src/Lit/Bolt/Router/BoltStubResolver.php
@@ -12,6 +12,9 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Standard stub resolver using DI container to resolve stubs
+ */
 class BoltStubResolver implements RouterStubResolverInterface
 {
     /**
@@ -30,9 +33,10 @@ class BoltStubResolver implements RouterStubResolverInterface
     }
 
     /**
-     * @param mixed $stub
+     * Resolve the stub and return a RequestHandler
+     *
+     * @param mixed $stub The stub value to be resolved.
      * @return RequestHandlerInterface
-     * @throws \ReflectionException
      */
     public function resolve($stub): RequestHandlerInterface
     {
@@ -62,7 +66,8 @@ class BoltStubResolver implements RouterStubResolverInterface
             throw $exception;
         }
 
-        /** @noinspection PhpIncompatibleReturnTypeInspection */
-        return $containerStub->instantiateFrom($this->container);
+        $handler = $containerStub->instantiateFrom($this->container);
+        assert($handler instanceof RequestHandlerInterface);
+        return $handler;
     }
 }

--- a/src/Lit/Bolt/Router/StubResolveException.php
+++ b/src/Lit/Bolt/Router/StubResolveException.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
+/**
+ * Stub resolving exception
+ */
 class StubResolveException extends \RuntimeException implements ThrowableResponseInterface
 {
     protected $stub;
@@ -17,6 +20,15 @@ class StubResolveException extends \RuntimeException implements ThrowableRespons
      */
     protected $factory;
 
+    /**
+     * StubResolveException constructor.
+     *
+     * @param mixed                    $stub     The problematic stub.
+     * @param ResponseFactoryInterface $factory  Response factory used to create not found response.
+     * @param Throwable|null           $previous Previous exception.
+     * @param string                   $message  Exception message.
+     * @param integer                  $code     Exception code.
+     */
     public function __construct(
         $stub,
         ResponseFactoryInterface $factory,
@@ -37,6 +49,9 @@ class StubResolveException extends \RuntimeException implements ThrowableRespons
         return $this->stub;
     }
 
+    /**
+     * @return ResponseInterface
+     */
     public function getResponse(): ResponseInterface
     {
         $response = $this->factory->createResponse(404);

--- a/src/Lit/Bolt/RouterConfiguration.php
+++ b/src/Lit/Bolt/RouterConfiguration.php
@@ -9,9 +9,17 @@ use Lit\Voltage\RouterDispatchHandler;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Configuration class for typical app using router.
+ */
 class RouterConfiguration
 {
-    public static function default()
+    /**
+     * configuration for typical app using router
+     *
+     * @return array
+     */
+    public static function default(): array
     {
         return [
             BoltApp::class => C::provideParameter([

--- a/src/Lit/Nexus/Derived/FrozenKeyValue.php
+++ b/src/Lit/Nexus/Derived/FrozenKeyValue.php
@@ -7,6 +7,9 @@ namespace Lit\Nexus\Derived;
 use Lit\Nexus\Interfaces\KeyValueInterface;
 use Lit\Nexus\Interfaces\ReadableKeyValueInterface;
 
+/**
+ * Derived ReadableKeyValueInterface class from a KeyValueInterface. Makes it readonly.
+ */
 class FrozenKeyValue implements ReadableKeyValueInterface
 {
     /**
@@ -19,8 +22,11 @@ class FrozenKeyValue implements ReadableKeyValueInterface
         $this->keyValue = $keyValue;
     }
 
+
     /**
-     * @param KeyValueInterface $keyValue
+     * Return a readonly instance of the given KeyValueInterface
+     *
+     * @param KeyValueInterface $keyValue The KeyValueInterface object.
      * @return static
      */
     public static function wrap(KeyValueInterface $keyValue)
@@ -32,7 +38,9 @@ class FrozenKeyValue implements ReadableKeyValueInterface
     }
 
     /**
-     * @param array|\ArrayAccess $content
+     * Wrap a offset content.
+     *
+     * @param array|\ArrayAccess $content The content.
      * @return static
      */
     public static function wrapOffset($content)
@@ -40,19 +48,11 @@ class FrozenKeyValue implements ReadableKeyValueInterface
         return self::wrap(OffsetKeyValue::wrap($content));
     }
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
     public function get(string $key)
     {
         return $this->keyValue->get($key);
     }
 
-    /**
-     * @param string $key
-     * @return boolean
-     */
     public function exists(string $key)
     {
         return $this->keyValue->exists($key);

--- a/src/Lit/Nexus/Derived/FrozenKeyValue.php
+++ b/src/Lit/Nexus/Derived/FrozenKeyValue.php
@@ -51,7 +51,7 @@ class FrozenKeyValue implements ReadableKeyValueInterface
 
     /**
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     public function exists(string $key)
     {

--- a/src/Lit/Nexus/Derived/FrozenValue.php
+++ b/src/Lit/Nexus/Derived/FrozenValue.php
@@ -40,7 +40,7 @@ class FrozenValue implements ReadableSingleValueInterface
     }
 
     /**
-     * @return bool
+     * @return boolean
      */
     public function exists()
     {

--- a/src/Lit/Nexus/Derived/FrozenValue.php
+++ b/src/Lit/Nexus/Derived/FrozenValue.php
@@ -7,6 +7,9 @@ namespace Lit\Nexus\Derived;
 use Lit\Nexus\Interfaces\ReadableSingleValueInterface;
 use Lit\Nexus\Interfaces\SingleValueInterface;
 
+/**
+ * Derived ReadableSingleValueInterface class from a SingleValueInterface. Makes it readonly.
+ */
 class FrozenValue implements ReadableSingleValueInterface
 {
     /**
@@ -20,7 +23,9 @@ class FrozenValue implements ReadableSingleValueInterface
     }
 
     /**
-     * @param SingleValueInterface $value
+     * Return a readonly instance of the given SingleValueInterface
+     *
+     * @param SingleValueInterface $value The SingleValueInterface object.
      * @return static
      */
     public static function wrap(SingleValueInterface $value)
@@ -31,17 +36,11 @@ class FrozenValue implements ReadableSingleValueInterface
         return new static($value);
     }
 
-    /**
-     * @return mixed
-     */
     public function get()
     {
         return $this->value->get();
     }
 
-    /**
-     * @return boolean
-     */
     public function exists()
     {
         return $this->value->exists();

--- a/src/Lit/Nexus/Derived/ObjectKeyValue.php
+++ b/src/Lit/Nexus/Derived/ObjectKeyValue.php
@@ -45,7 +45,7 @@ class ObjectKeyValue implements KeyValueInterface
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      * @return void
      */
     public function set(string $key, $value)
@@ -73,7 +73,7 @@ class ObjectKeyValue implements KeyValueInterface
 
     /**
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     public function exists(string $key)
     {

--- a/src/Lit/Nexus/Derived/ObjectKeyValue.php
+++ b/src/Lit/Nexus/Derived/ObjectKeyValue.php
@@ -7,6 +7,9 @@ namespace Lit\Nexus\Derived;
 use Lit\Nexus\Interfaces\KeyValueInterface;
 use Lit\Nexus\Traits\KeyValueTrait;
 
+/**
+ * KV object of an object content
+ */
 class ObjectKeyValue implements KeyValueInterface
 {
     use KeyValueTrait;
@@ -27,7 +30,7 @@ class ObjectKeyValue implements KeyValueInterface
 
 
     /**
-     * @param object $content
+     * @param object $content The content to be wrapped.
      * @return static
      */
     public static function wrap($content)
@@ -43,46 +46,26 @@ class ObjectKeyValue implements KeyValueInterface
         throw new \InvalidArgumentException();
     }
 
-    /**
-     * @param string $key
-     * @param mixed  $value
-     * @return void
-     */
     public function set(string $key, $value)
     {
         $this->content->{$key} = $value;
     }
 
-    /**
-     * @param string $key
-     * @return void
-     */
     public function delete(string $key)
     {
         unset($this->content->{$key});
     }
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
     public function get(string $key)
     {
         return $this->content->{$key};
     }
 
-    /**
-     * @param string $key
-     * @return boolean
-     */
     public function exists(string $key)
     {
         return isset($this->content->{$key});
     }
 
-    /**
-     * @return object
-     */
     public function getContent()
     {
         return $this->content;

--- a/src/Lit/Nexus/Derived/OffsetKeyValue.php
+++ b/src/Lit/Nexus/Derived/OffsetKeyValue.php
@@ -37,7 +37,7 @@ class OffsetKeyValue implements KeyValueInterface
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      * @return void
      */
     public function set(string $key, $value)
@@ -65,7 +65,7 @@ class OffsetKeyValue implements KeyValueInterface
 
     /**
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     public function exists(string $key)
     {

--- a/src/Lit/Nexus/Derived/OffsetKeyValue.php
+++ b/src/Lit/Nexus/Derived/OffsetKeyValue.php
@@ -7,6 +7,9 @@ namespace Lit\Nexus\Derived;
 use Lit\Nexus\Interfaces\KeyValueInterface;
 use Lit\Nexus\Traits\KeyValueTrait;
 
+/**
+ * KV object of an offset content (array or ArrayAccess)
+ */
 class OffsetKeyValue implements KeyValueInterface
 {
     use KeyValueTrait;
@@ -23,7 +26,7 @@ class OffsetKeyValue implements KeyValueInterface
     }
 
     /**
-     * @param array|\ArrayAccess $content
+     * @param array|\ArrayAccess $content The content to be wrapped.
      * @return static
      */
     public static function wrap($content)
@@ -35,38 +38,21 @@ class OffsetKeyValue implements KeyValueInterface
         return new static($content);
     }
 
-    /**
-     * @param string $key
-     * @param mixed  $value
-     * @return void
-     */
     public function set(string $key, $value)
     {
         $this->content[$key] = $value;
     }
 
-    /**
-     * @param string $key
-     * @return void
-     */
     public function delete(string $key)
     {
         unset($this->content[$key]);
     }
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
     public function get(string $key)
     {
         return $this->content[$key];
     }
 
-    /**
-     * @param string $key
-     * @return boolean
-     */
     public function exists(string $key)
     {
         return isset($this->content[$key]);

--- a/src/Lit/Nexus/Derived/PrefixKeyValue.php
+++ b/src/Lit/Nexus/Derived/PrefixKeyValue.php
@@ -7,6 +7,9 @@ namespace Lit\Nexus\Derived;
 use Lit\Nexus\Interfaces\KeyValueInterface;
 use Lit\Nexus\Traits\KeyValueTrait;
 
+/**
+ * Wraps another KeyValueInterface with fixed prefix.
+ */
 class PrefixKeyValue implements KeyValueInterface
 {
     use KeyValueTrait;
@@ -20,7 +23,7 @@ class PrefixKeyValue implements KeyValueInterface
      */
     protected $prefix;
 
-    protected function __construct(KeyValueInterface $store, $prefix)
+    protected function __construct(KeyValueInterface $store, string $prefix)
     {
         if (empty($prefix)) {
             throw new \InvalidArgumentException();
@@ -30,43 +33,33 @@ class PrefixKeyValue implements KeyValueInterface
         $this->prefix = $prefix;
     }
 
-    public static function wrap(KeyValueInterface $store, $prefix)
+    /**
+     * Return a new KeyValueInterface which always prepend prefix to the origin KeyValueInterface.
+     *
+     * @param KeyValueInterface $store  The KeyValueInterface object.
+     * @param string            $prefix The prefix.
+     * @return PrefixKeyValue
+     */
+    public static function wrap(KeyValueInterface $store, string $prefix)
     {
         return new self($store, $prefix);
     }
 
-    /**
-     * @param string $key
-     * @param mixed  $value
-     * @return void
-     */
     public function set(string $key, $value)
     {
         $this->store->set($this->key($key), $value);
     }
 
-    /**
-     * @param string $key
-     * @return void
-     */
     public function delete(string $key)
     {
         $this->store->delete($this->key($key));
     }
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
     public function get(string $key)
     {
         return $this->store->get($this->key($key));
     }
 
-    /**
-     * @param string $key
-     * @return boolean
-     */
     public function exists(string $key)
     {
         return $this->store->exists($this->key($key));

--- a/src/Lit/Nexus/Derived/PrefixKeyValue.php
+++ b/src/Lit/Nexus/Derived/PrefixKeyValue.php
@@ -37,7 +37,7 @@ class PrefixKeyValue implements KeyValueInterface
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      * @return void
      */
     public function set(string $key, $value)
@@ -65,7 +65,7 @@ class PrefixKeyValue implements KeyValueInterface
 
     /**
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     public function exists(string $key)
     {

--- a/src/Lit/Nexus/Derived/SlicedValue.php
+++ b/src/Lit/Nexus/Derived/SlicedValue.php
@@ -22,7 +22,7 @@ class SlicedValue implements SingleValueInterface
 
     /**
      * @param KeyValueInterface $keyValue
-     * @param string $key
+     * @param string            $key
      */
     public function __construct(KeyValueInterface $keyValue, $key)
     {
@@ -33,7 +33,7 @@ class SlicedValue implements SingleValueInterface
 
     /**
      * @param KeyValueInterface $keyValue
-     * @param string $key
+     * @param string            $key
      * @return static
      */
     public static function slice(KeyValueInterface $keyValue, string $key)
@@ -50,7 +50,7 @@ class SlicedValue implements SingleValueInterface
     }
 
     /**
-     * @return bool
+     * @return boolean
      */
     public function exists()
     {

--- a/src/Lit/Nexus/Derived/SlicedValue.php
+++ b/src/Lit/Nexus/Derived/SlicedValue.php
@@ -8,6 +8,9 @@ use Lit\Nexus\Interfaces\KeyValueInterface;
 use Lit\Nexus\Interfaces\SingleValueInterface;
 use Lit\Nexus\Traits\SingleValueTrait;
 
+/**
+ * Derived class that given a KeyValueInterface object and a key, access its content
+ */
 class SlicedValue implements SingleValueInterface
 {
     use SingleValueTrait;
@@ -20,11 +23,7 @@ class SlicedValue implements SingleValueInterface
      */
     private $key;
 
-    /**
-     * @param KeyValueInterface $keyValue
-     * @param string            $key
-     */
-    public function __construct(KeyValueInterface $keyValue, $key)
+    public function __construct(KeyValueInterface $keyValue, string $key)
     {
 
         $this->keyValue = $keyValue;
@@ -32,8 +31,10 @@ class SlicedValue implements SingleValueInterface
     }
 
     /**
-     * @param KeyValueInterface $keyValue
-     * @param string            $key
+     * Make a SingleValueInterface from the KeyValueInterface and key.
+     *
+     * @param KeyValueInterface $keyValue The KeyValueInterface object.
+     * @param string            $key      The key.
      * @return static
      */
     public static function slice(KeyValueInterface $keyValue, string $key)
@@ -41,34 +42,21 @@ class SlicedValue implements SingleValueInterface
         return new static($keyValue, $key);
     }
 
-    /**
-     * @return mixed
-     */
     public function get()
     {
         return $this->keyValue->get($this->key);
     }
 
-    /**
-     * @return boolean
-     */
     public function exists()
     {
         return $this->keyValue->exists($this->key);
     }
 
-    /**
-     * @param mixed $value
-     * @return void
-     */
     public function set($value)
     {
         $this->keyValue->set($this->key, $value);
     }
 
-    /**
-     * @return void
-     */
     public function delete()
     {
         $this->keyValue->delete($this->key);

--- a/src/Lit/Nexus/Interfaces/KeyValueInterface.php
+++ b/src/Lit/Nexus/Interfaces/KeyValueInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lit\Nexus\Interfaces;
 
+/**
+ * KeyValueInterface represents an object with some inner value which can be accessed by string key.
+ */
 interface KeyValueInterface extends ReadableKeyValueInterface
 {
 
@@ -11,8 +14,8 @@ interface KeyValueInterface extends ReadableKeyValueInterface
      * Write the key with value
      * Supported value format is undefined. implementation is free to decide, and throw some Exception on illegal value
      *
-     * @param string $key
-     * @param mixed  $value
+     * @param string $key   The key.
+     * @param mixed  $value The value.
      * @return void
      */
     public function set(string $key, $value);
@@ -21,7 +24,7 @@ interface KeyValueInterface extends ReadableKeyValueInterface
      * Remove value in the key
      * The bahaviour of deleting unexist key is undefined, implementation is free to ignore it, or throw something out.
      *
-     * @param string $key
+     * @param string $key The key.
      * @return void
      */
     public function delete(string $key);

--- a/src/Lit/Nexus/Interfaces/KeyValueInterface.php
+++ b/src/Lit/Nexus/Interfaces/KeyValueInterface.php
@@ -12,7 +12,7 @@ interface KeyValueInterface extends ReadableKeyValueInterface
      * Supported value format is undefined. implementation is free to decide, and throw some Exception on illegal value
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      * @return void
      */
     public function set(string $key, $value);

--- a/src/Lit/Nexus/Interfaces/ReadableKeyValueInterface.php
+++ b/src/Lit/Nexus/Interfaces/ReadableKeyValueInterface.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Lit\Nexus\Interfaces;
 
+/**
+ * ReadableKeyValueInterface represents an object with some inner value which can be read by string key.
+ */
 interface ReadableKeyValueInterface
 {
     /**
      * Read the value in key and return that.
      * Behaviour of read an unexisting key is undefined.
      *
-     * @param string $key
+     * @param string $key The key.
      * @return mixed
      */
     public function get(string $key);
@@ -18,7 +21,7 @@ interface ReadableKeyValueInterface
     /**
      * Return whether the key exists
      *
-     * @param string $key
+     * @param string $key The key.
      * @return boolean
      */
     public function exists(string $key);

--- a/src/Lit/Nexus/Interfaces/ReadableKeyValueInterface.php
+++ b/src/Lit/Nexus/Interfaces/ReadableKeyValueInterface.php
@@ -19,7 +19,7 @@ interface ReadableKeyValueInterface
      * Return whether the key exists
      *
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     public function exists(string $key);
 }

--- a/src/Lit/Nexus/Interfaces/ReadableSingleValueInterface.php
+++ b/src/Lit/Nexus/Interfaces/ReadableSingleValueInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lit\Nexus\Interfaces;
 
+/**
+ * ReadableSingleValueInterface represent a single value that can be read.
+ */
 interface ReadableSingleValueInterface
 {
     /**

--- a/src/Lit/Nexus/Interfaces/ReadableSingleValueInterface.php
+++ b/src/Lit/Nexus/Interfaces/ReadableSingleValueInterface.php
@@ -16,7 +16,7 @@ interface ReadableSingleValueInterface
     /**
      * Return whether this value exists
      *
-     * @return bool
+     * @return boolean
      */
     public function exists();
 }

--- a/src/Lit/Nexus/Interfaces/SingleValueInterface.php
+++ b/src/Lit/Nexus/Interfaces/SingleValueInterface.php
@@ -4,13 +4,16 @@ declare(strict_types=1);
 
 namespace Lit\Nexus\Interfaces;
 
+/**
+ * SingleValueInterface represent a single value that can be accessed.
+ */
 interface SingleValueInterface extends ReadableSingleValueInterface
 {
 
     /**
      * Update the value
      *
-     * @param mixed $value
+     * @param mixed $value The value.
      * @return void
      */
     public function set($value);

--- a/src/Lit/Nexus/Traits/EmbedKeyValueTrait.php
+++ b/src/Lit/Nexus/Traits/EmbedKeyValueTrait.php
@@ -6,6 +6,9 @@ namespace Lit\Nexus\Traits;
 
 use Lit\Nexus\Interfaces\KeyValueInterface;
 
+/**
+ * KeyValueInterface implementation which delegating to $innerKeyValue
+ */
 trait EmbedKeyValueTrait
 {
     /**
@@ -13,38 +16,21 @@ trait EmbedKeyValueTrait
      */
     protected $innerKeyValue;
 
-    /**
-     * @param string $key
-     * @param mixed  $value
-     * @return void
-     */
     public function set($key, $value)
     {
         $this->innerKeyValue->set($key, $value);
     }
 
-    /**
-     * @param string $key
-     * @return void
-     */
     public function delete($key)
     {
         $this->innerKeyValue->delete($key);
     }
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
     public function get($key)
     {
         return $this->innerKeyValue->get($key);
     }
 
-    /**
-     * @param string $key
-     * @return boolean
-     */
     public function exists($key)
     {
         return $this->innerKeyValue->exists($key);

--- a/src/Lit/Nexus/Traits/EmbedKeyValueTrait.php
+++ b/src/Lit/Nexus/Traits/EmbedKeyValueTrait.php
@@ -15,7 +15,7 @@ trait EmbedKeyValueTrait
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      * @return void
      */
     public function set($key, $value)
@@ -43,7 +43,7 @@ trait EmbedKeyValueTrait
 
     /**
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     public function exists($key)
     {

--- a/src/Lit/Nexus/Traits/KeyValueArrayAccessTrait.php
+++ b/src/Lit/Nexus/Traits/KeyValueArrayAccessTrait.php
@@ -33,7 +33,7 @@ trait KeyValueArrayAccessTrait
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      * @return void
      */
     abstract public function set($key, $value);
@@ -52,7 +52,7 @@ trait KeyValueArrayAccessTrait
 
     /**
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     abstract public function exists($key);
 }

--- a/src/Lit/Nexus/Traits/KeyValueArrayAccessTrait.php
+++ b/src/Lit/Nexus/Traits/KeyValueArrayAccessTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Lit\Nexus\Traits;
 
 /**
- * make IKeyValue accessible via \ArrayAccess
- *
- * @package Lit\Nexus\Traits
+ * \ArrayAccess implementation for KeyValueInterface
  */
 trait KeyValueArrayAccessTrait
 {
@@ -31,28 +29,11 @@ trait KeyValueArrayAccessTrait
         $this->delete($offset);
     }
 
-    /**
-     * @param string $key
-     * @param mixed  $value
-     * @return void
-     */
     abstract public function set($key, $value);
 
-    /**
-     * @param string $key
-     * @return void
-     */
     abstract public function delete($key);
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
     abstract public function get($key);
 
-    /**
-     * @param string $key
-     * @return boolean
-     */
     abstract public function exists($key);
 }

--- a/src/Lit/Nexus/Traits/KeyValueObjectAccessTrait.php
+++ b/src/Lit/Nexus/Traits/KeyValueObjectAccessTrait.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lit\Nexus\Traits;
 
+/**
+ * Magic methods for KeyValueInterface, makes it's content accessible as object properties.
+ */
 trait KeyValueObjectAccessTrait
 {
     public function __get($name)
@@ -26,28 +29,11 @@ trait KeyValueObjectAccessTrait
         $this->delete($name);
     }
 
-    /**
-     * @param string $key
-     * @param mixed  $value
-     * @return void
-     */
     abstract public function set($key, $value);
 
-    /**
-     * @param string $key
-     * @return void
-     */
     abstract public function delete($key);
 
-    /**
-     * @param string $key
-     * @return mixed
-     */
     abstract public function get($key);
 
-    /**
-     * @param string $key
-     * @return boolean
-     */
     abstract public function exists($key);
 }

--- a/src/Lit/Nexus/Traits/KeyValueObjectAccessTrait.php
+++ b/src/Lit/Nexus/Traits/KeyValueObjectAccessTrait.php
@@ -28,7 +28,7 @@ trait KeyValueObjectAccessTrait
 
     /**
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      * @return void
      */
     abstract public function set($key, $value);
@@ -47,7 +47,7 @@ trait KeyValueObjectAccessTrait
 
     /**
      * @param string $key
-     * @return bool
+     * @return boolean
      */
     abstract public function exists($key);
 }

--- a/src/Lit/Nexus/Traits/KeyValueTrait.php
+++ b/src/Lit/Nexus/Traits/KeyValueTrait.php
@@ -9,6 +9,9 @@ use Lit\Nexus\Derived\PrefixKeyValue;
 use Lit\Nexus\Derived\SlicedValue;
 use Lit\Nexus\Interfaces\KeyValueInterface;
 
+/**
+ * Wrapper methods for KeyValueInterface
+ */
 trait KeyValueTrait
 {
     /**
@@ -23,7 +26,7 @@ trait KeyValueTrait
     }
 
     /**
-     * @param string $key
+     * @param string $key The key.
      * @return SlicedValue
      */
     public function slice(string $key)
@@ -35,16 +38,16 @@ trait KeyValueTrait
     }
 
     /**
-     * @param string $prefix
-     * @param string $delimeter
+     * @param string $prefix    The prefix.
+     * @param string $delimeter The delimeter.
      * @return PrefixKeyValue
      */
     public function prefix(string $prefix, string $delimeter = '!!')
     {
-        /**
-         * @var KeyValueInterface|self $this
-         */
         assert($this instanceof KeyValueInterface);
+        /**
+         * @var KeyValueInterface $this
+         */
         return PrefixKeyValue::wrap($this, $prefix . $delimeter);
     }
 }

--- a/src/Lit/Nexus/Utilities/Inspector.php
+++ b/src/Lit/Nexus/Utilities/Inspector.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lit\Nexus\Utilities;
 
+/**
+ * A minimist error inspector
+ */
 class Inspector
 {
     protected const EXCEPTION_MESSAGE = <<<HTML
@@ -45,10 +48,6 @@ TEXT;
         throw new \ErrorException($errstr, $errno, 1, $errfile, $errline);
     }
 
-
-    /**
-     * @param \Exception $exception
-     */
     public static function exceptionHandler($exception)
     {
         $msg = sprintf(

--- a/src/Lit/Nexus/Utilities/KeyValueUtility.php
+++ b/src/Lit/Nexus/Utilities/KeyValueUtility.php
@@ -6,12 +6,17 @@ namespace Lit\Nexus\Utilities;
 
 use Lit\Nexus\Interfaces\SingleValueInterface;
 
+/**
+ * Utilities about KeyValueInterface
+ */
 class KeyValueUtility
 {
     /**
-     * @param SingleValueInterface $store
-     * @param callable             $compute
-     * @return mixed
+     * Get the value from SingleValueInterface, or call $compute callback and write to it.
+     *
+     * @param SingleValueInterface $store   The storage.
+     * @param callable             $compute The method to create the value.
+     * @return mixed The value.
      */
     public static function getOrSet(SingleValueInterface $store, callable $compute)
     {

--- a/src/Lit/Nexus/Utilities/KeyValueUtility.php
+++ b/src/Lit/Nexus/Utilities/KeyValueUtility.php
@@ -10,7 +10,7 @@ class KeyValueUtility
 {
     /**
      * @param SingleValueInterface $store
-     * @param callable $compute
+     * @param callable             $compute
      * @return mixed
      */
     public static function getOrSet(SingleValueInterface $store, callable $compute)

--- a/src/Lit/Nexus/Utilities/SimpleTemplate.php
+++ b/src/Lit/Nexus/Utilities/SimpleTemplate.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Lit\Nexus\Utilities;
 
+/**
+ * Simple string template
+ */
 class SimpleTemplate
 {
     protected $tag_re = '#`([^`\r\n]+)(?:[\r\n`])#';
@@ -13,7 +16,7 @@ class SimpleTemplate
     protected $post = [
         '!!TPL_PHP!!' => '<?=\'<\'?>?',
     ];
-    protected $rule = array(
+    protected $rule = [
         'if' => '<?php if(%0):?>',
         'else' => '<?php else:?>',
         'elif' => '<?php elseif (%0):?>',
@@ -22,16 +25,13 @@ class SimpleTemplate
         '/loop' => '<?php endforeach;?>',
         'php' => "<?php %0",
         '/php' => '?>',
-    );
+    ];
     /**
      * @var string
      */
     protected $code;
     protected $compiledCode;
 
-    /**
-     * @param string $templateCode
-     */
     protected function __construct(string $templateCode)
     {
         $this->code = $templateCode;
@@ -42,12 +42,20 @@ class SimpleTemplate
         return new static($templateCode);
     }
 
-    public function render($data)
+    /**
+     * render a string
+     *
+     * @param array $data The input data.
+     * @return string
+     */
+    public function render(array $data): string
     {
         ob_start();
         extract($data);
         eval('?>' . $this->compile());
-        return ob_get_clean();
+        $ret = ob_get_clean();
+        assert(is_string($ret));
+        return $ret;
     }
 
     public function compile()

--- a/src/Lit/Nexus/Void/VoidKeyValue.php
+++ b/src/Lit/Nexus/Void/VoidKeyValue.php
@@ -8,9 +8,7 @@ use Lit\Nexus\Interfaces\KeyValueInterface;
 use Lit\Nexus\Traits\KeyValueTrait;
 
 /**
- * Class VoidKeyValue
- * @package Lit\Nexus\Void
- * @SuppressWarnings(PHPMD)
+ * Special KeyValueInterface that contains nothing and silently ignore any write.
  */
 class VoidKeyValue implements KeyValueInterface
 {

--- a/src/Lit/Nexus/Void/VoidSingleValue.php
+++ b/src/Lit/Nexus/Void/VoidSingleValue.php
@@ -8,9 +8,7 @@ use Lit\Nexus\Interfaces\SingleValueInterface;
 use Lit\Nexus\Traits\SingleValueTrait;
 
 /**
- * Class VoidSingleValue
- * @package Lit\Nexus\Void
- * @SuppressWarnings(PHPMD)
+ * Special SingleValueInterface that contains nothing and silently ignore any write.
  */
 class VoidSingleValue implements SingleValueInterface
 {

--- a/src/Lit/Nimo/Handlers/AbstractHandler.php
+++ b/src/Lit/Nimo/Handlers/AbstractHandler.php
@@ -8,6 +8,9 @@ use Lit\Nimo\Traits\HandlerCompositeTrait;
 use Lit\Nimo\Traits\HandlerTrait;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Base class for RequestHandler
+ */
 abstract class AbstractHandler implements RequestHandlerInterface
 {
     use HandlerTrait;

--- a/src/Lit/Nimo/Handlers/AbstractWrapperHandler.php
+++ b/src/Lit/Nimo/Handlers/AbstractWrapperHandler.php
@@ -6,6 +6,9 @@ namespace Lit\Nimo\Handlers;
 
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Base class for handler wrapper.
+ */
 abstract class AbstractWrapperHandler extends AbstractHandler
 {
     /**

--- a/src/Lit/Nimo/Handlers/CallableHandler.php
+++ b/src/Lit/Nimo/Handlers/CallableHandler.php
@@ -7,6 +7,9 @@ namespace Lit\Nimo\Handlers;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Converts a callback to a RequestHandlerInterface
+ */
 class CallableHandler extends AbstractHandler
 {
     /**

--- a/src/Lit/Nimo/Handlers/FixedResponseHandler.php
+++ b/src/Lit/Nimo/Handlers/FixedResponseHandler.php
@@ -7,12 +7,15 @@ namespace Lit\Nimo\Handlers;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Handler that always return fixed response.
+ */
 class FixedResponseHandler extends AbstractHandler
 {
     protected $fixedResponse;
 
     /**
-     * @param ResponseInterface $response always return this response
+     * @param ResponseInterface $response The fixed response.
      */
     public function __construct(ResponseInterface $response)
     {

--- a/src/Lit/Nimo/Handlers/MiddlewareIncluedHandler.php
+++ b/src/Lit/Nimo/Handlers/MiddlewareIncluedHandler.php
@@ -8,6 +8,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Wraps a handler by given middleware.
+ */
 class MiddlewareIncluedHandler extends AbstractWrapperHandler
 {
     /**

--- a/src/Lit/Nimo/Interfaces/RequestPredictionInterface.php
+++ b/src/Lit/Nimo/Interfaces/RequestPredictionInterface.php
@@ -12,7 +12,7 @@ interface RequestPredictionInterface
      * Run the prediction and return whether it's matched or not
      *
      * @param ServerRequestInterface $request
-     * @return bool
+     * @return boolean
      */
     public function isTrue(ServerRequestInterface $request): bool;
 }

--- a/src/Lit/Nimo/Interfaces/RequestPredictionInterface.php
+++ b/src/Lit/Nimo/Interfaces/RequestPredictionInterface.php
@@ -6,12 +6,15 @@ namespace Lit\Nimo\Interfaces;
 
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * RequestPredictionInterface represents a boolean prediction about a response
+ */
 interface RequestPredictionInterface
 {
     /**
      * Run the prediction and return whether it's matched or not
      *
-     * @param ServerRequestInterface $request
+     * @param ServerRequestInterface $request The request.
      * @return boolean
      */
     public function isTrue(ServerRequestInterface $request): bool;

--- a/src/Lit/Nimo/Middlewares/AbstractConditionMiddleware.php
+++ b/src/Lit/Nimo/Middlewares/AbstractConditionMiddleware.php
@@ -8,6 +8,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Base class for middleware wrapper that skip inner logic sometimes.
+ */
 abstract class AbstractConditionMiddleware extends AbstractWrapperMiddleware
 {
     protected function main(): ResponseInterface

--- a/src/Lit/Nimo/Middlewares/AbstractMiddleware.php
+++ b/src/Lit/Nimo/Middlewares/AbstractMiddleware.php
@@ -9,6 +9,9 @@ use Lit\Nimo\Traits\MiddlewareCompositeTrait;
 use Lit\Nimo\Traits\MiddlewareTrait;
 use Psr\Http\Server\MiddlewareInterface;
 
+/**
+ * Base middleware class
+ */
 abstract class AbstractMiddleware implements MiddlewareInterface
 {
     use MiddlewareTrait;

--- a/src/Lit/Nimo/Middlewares/AbstractWrapperMiddleware.php
+++ b/src/Lit/Nimo/Middlewares/AbstractWrapperMiddleware.php
@@ -6,6 +6,9 @@ namespace Lit\Nimo\Middlewares;
 
 use Psr\Http\Server\MiddlewareInterface;
 
+/**
+ * Base class for middleware wrapper that wraps another middleware.
+ */
 abstract class AbstractWrapperMiddleware extends AbstractMiddleware
 {
     /**

--- a/src/Lit/Nimo/Middlewares/CatchMiddleware.php
+++ b/src/Lit/Nimo/Middlewares/CatchMiddleware.php
@@ -8,6 +8,9 @@ use Lit\Nimo\Interfaces\ExceptionHandlerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
 
+/**
+ * Middleware wrapper that try to catch soem exception when running inner middleware.
+ */
 class CatchMiddleware extends AbstractWrapperMiddleware
 {
     /**

--- a/src/Lit/Nimo/Middlewares/FixedResponseMiddleware.php
+++ b/src/Lit/Nimo/Middlewares/FixedResponseMiddleware.php
@@ -6,12 +6,15 @@ namespace Lit\Nimo\Middlewares;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * A middleware that never delegate and always return a fixed response.
+ */
 class FixedResponseMiddleware extends AbstractMiddleware
 {
     protected $fixedResponse;
 
     /**
-     * @param ResponseInterface $response always return this response
+     * @param ResponseInterface $response The fixed response.
      */
     public function __construct(ResponseInterface $response)
     {

--- a/src/Lit/Nimo/Middlewares/MiddlewarePipe.php
+++ b/src/Lit/Nimo/Middlewares/MiddlewarePipe.php
@@ -10,6 +10,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Pipe or chain of middlewares. This middleware is designed to run multiple middlewares one by one.
+ */
 class MiddlewarePipe extends AbstractMiddleware
 {
     /**
@@ -35,7 +38,7 @@ class MiddlewarePipe extends AbstractMiddleware
      * return $this
      * note this method would modify $this
      *
-     * @param MiddlewareInterface $middleware
+     * @param MiddlewareInterface $middleware The middleware to be append.
      * @return $this
      */
     public function append(MiddlewareInterface $middleware): MiddlewarePipe
@@ -49,7 +52,7 @@ class MiddlewarePipe extends AbstractMiddleware
      * return $this
      * note this method would modify $this
      *
-     * @param MiddlewareInterface $middleware
+     * @param MiddlewareInterface $middleware The middleware to be prepend.
      * @return $this
      */
     public function prepend(MiddlewareInterface $middleware): MiddlewarePipe
@@ -66,7 +69,7 @@ class MiddlewarePipe extends AbstractMiddleware
     }
 
     /**
-     * @param ServerRequestInterface $request
+     * @param ServerRequestInterface $request The request.
      * @return ResponseInterface
      */
     protected function loop(ServerRequestInterface $request): ResponseInterface

--- a/src/Lit/Nimo/Middlewares/NoopMiddleware.php
+++ b/src/Lit/Nimo/Middlewares/NoopMiddleware.php
@@ -6,6 +6,9 @@ namespace Lit\Nimo\Middlewares;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * A middleware does nothing is a still valid middleware and can be useful sometimes.
+ */
 final class NoopMiddleware extends AbstractMiddleware
 {
     public static function instance()

--- a/src/Lit/Nimo/Middlewares/PredictionWrapperMiddleware.php
+++ b/src/Lit/Nimo/Middlewares/PredictionWrapperMiddleware.php
@@ -9,6 +9,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Wraps a middleware, skip inner logic when the RequestPredictionInterface fail (or pass, by `reverted` option)
+ */
 class PredictionWrapperMiddleware extends AbstractConditionMiddleware
 {
     /**

--- a/src/Lit/Nimo/Traits/AttachToRequestTrait.php
+++ b/src/Lit/Nimo/Traits/AttachToRequestTrait.php
@@ -7,14 +7,17 @@ namespace Lit\Nimo\Traits;
 use Psr\Http\Message\ServerRequestInterface;
 
 /**
- * Trait AttachToRequestTrait
- * @package Lit\Nimo\Traits
+ * A common pattern that an object write itself to PSR request attributes.
+ * By default the key will be the class name, can be override with class const `ATTR_KEY`.
+ *
  * @property ServerRequestInterface $request
  */
 trait AttachToRequestTrait
 {
     /**
-     * @param ServerRequestInterface $request
+     * Get self from request (attributes).
+     *
+     * @param ServerRequestInterface $request The request.
      * @return static
      */
     public static function fromRequest(ServerRequestInterface $request)
@@ -31,7 +34,9 @@ trait AttachToRequestTrait
     }
 
     /**
-     * @param ServerRequestInterface $request
+     * Attach self to the request (in attributes) and return the new one.
+     *
+     * @param ServerRequestInterface $request The request.
      * @return ServerRequestInterface
      */
     protected function attachToRequest(ServerRequestInterface $request = null): ServerRequestInterface

--- a/src/Lit/Nimo/Traits/MiddlewareCompositeTrait.php
+++ b/src/Lit/Nimo/Traits/MiddlewareCompositeTrait.php
@@ -11,12 +11,15 @@ use Lit\Nimo\Middlewares\MiddlewarePipe;
 use Lit\Nimo\Middlewares\PredictionWrapperMiddleware;
 use Psr\Http\Server\MiddlewareInterface;
 
+/**
+ * Inludes some wrapping and compositing method about middleware.
+ */
 trait MiddlewareCompositeTrait
 {
     /**
      * append $middleware after this one, return the new $middlewareStack
      *
-     * @param MiddlewareInterface $middleware
+     * @param MiddlewareInterface $middleware The middleware.
      * @return MiddlewarePipe
      */
     public function append(MiddlewareInterface $middleware): MiddlewarePipe
@@ -32,7 +35,7 @@ trait MiddlewareCompositeTrait
     /**
      * prepend $middleware before this one, return the new $middlewareStack
      *
-     * @param MiddlewareInterface $middleware
+     * @param MiddlewareInterface $middleware The middleware.
      * @return MiddlewarePipe
      */
     public function prepend(MiddlewareInterface $middleware): MiddlewarePipe
@@ -45,18 +48,37 @@ trait MiddlewareCompositeTrait
             ->prepend($middleware);
     }
 
+    /**
+     * return a new middleware that only take effect when the prediction is passed.
+     *
+     * @param RequestPredictionInterface $requestPrediction The prediction.
+     * @return PredictionWrapperMiddleware
+     */
     public function when(RequestPredictionInterface $requestPrediction): PredictionWrapperMiddleware
     {
         /** @var MiddlewareInterface $this */
         return new PredictionWrapperMiddleware($this, $requestPrediction);
     }
 
+    /**
+     * return a new middleware that only take effect when the prediction is NOT passed.
+     *
+     * @param RequestPredictionInterface $requestPrediction The prediction.
+     * @return PredictionWrapperMiddleware
+     */
     public function unless(RequestPredictionInterface $requestPrediction): PredictionWrapperMiddleware
     {
         /** @var MiddlewareInterface $this */
         return new PredictionWrapperMiddleware($this, $requestPrediction, true);
     }
 
+    /**
+     * wraps this middleware by try catch.
+     *
+     * @param ExceptionHandlerInterface $catcher    The exception handler.
+     * @param string                    $catchClass The exception type to be caught.
+     * @return CatchMiddleware
+     */
     public function catch(ExceptionHandlerInterface $catcher, string $catchClass = \Throwable::class): CatchMiddleware
     {
         return new CatchMiddleware($this, $catcher, $catchClass);

--- a/src/Lit/Router/FastRoute/ArgumentHandler/ArgumentToAttribute.php
+++ b/src/Lit/Router/FastRoute/ArgumentHandler/ArgumentToAttribute.php
@@ -6,6 +6,9 @@ namespace Lit\Router\FastRoute\ArgumentHandler;
 
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Write route arguments to request attributes.
+ */
 class ArgumentToAttribute implements ArgumentHandlerInterface
 {
     public function attachArguments(

--- a/src/Lit/Router/FastRoute/ArgumentHandler/RouteArgumentBag.php
+++ b/src/Lit/Router/FastRoute/ArgumentHandler/RouteArgumentBag.php
@@ -8,6 +8,9 @@ use Lit\Nexus\Interfaces\ReadableKeyValueInterface;
 use Lit\Nimo\Traits\AttachToRequestTrait;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Contains all route arguments and attach to request.
+ */
 class RouteArgumentBag implements ReadableKeyValueInterface, ArgumentHandlerInterface
 {
     use AttachToRequestTrait;

--- a/src/Lit/Router/FastRoute/CachedDispatcher.php
+++ b/src/Lit/Router/FastRoute/CachedDispatcher.php
@@ -10,6 +10,9 @@ use FastRoute\RouteCollector;
 use FastRoute\RouteParser;
 use Lit\Nexus\Interfaces\SingleValueInterface;
 
+/**
+ * FastRoute dispatcher wrapper with cache support
+ */
 class CachedDispatcher implements Dispatcher
 {
     /**
@@ -39,19 +42,19 @@ class CachedDispatcher implements Dispatcher
 
     /**
      * RouteDispatcher constructor.
-     * @param SingleValueInterface $cache
-     * @param RouteParser          $routeParser
-     * @param DataGenerator        $dataGenerator
-     * @param callable             $routeDefinition
-     * @param string               $dispatcherClass
-     * @internal param RouteCollector $routeCollector
+     *
+     * @param SingleValueInterface $cache           The cache storage, should be able to serialize plain php array.
+     * @param RouteParser          $routeParser     The routeParser.
+     * @param DataGenerator        $dataGenerator   The dataGenerator.
+     * @param callable             $routeDefinition The routeDefinition.
+     * @param string               $dispatcherClass The dispatcher class name.
      */
     public function __construct(
         SingleValueInterface $cache,
         RouteParser $routeParser,
         DataGenerator $dataGenerator,
         callable $routeDefinition,
-        $dispatcherClass
+        string $dispatcherClass
     ) {
         $this->cache = $cache;
         $this->routeParser = $routeParser;

--- a/src/Lit/Router/FastRoute/CachedDispatcher.php
+++ b/src/Lit/Router/FastRoute/CachedDispatcher.php
@@ -40,10 +40,10 @@ class CachedDispatcher implements Dispatcher
     /**
      * RouteDispatcher constructor.
      * @param SingleValueInterface $cache
-     * @param RouteParser $routeParser
-     * @param DataGenerator $dataGenerator
-     * @param callable $routeDefinition
-     * @param string $dispatcherClass
+     * @param RouteParser          $routeParser
+     * @param DataGenerator        $dataGenerator
+     * @param callable             $routeDefinition
+     * @param string               $dispatcherClass
      * @internal param RouteCollector $routeCollector
      */
     public function __construct(

--- a/src/Lit/Router/FastRoute/FastRouteConfiguration.php
+++ b/src/Lit/Router/FastRoute/FastRouteConfiguration.php
@@ -17,6 +17,9 @@ use Lit\Nexus\Void\VoidSingleValue;
 use Lit\Voltage\Interfaces\RouterInterface;
 use Lit\Voltage\Interfaces\RouterStubResolverInterface;
 
+/**
+ * Configuration for FastRoute router application
+ */
 class FastRouteConfiguration
 {
     public static function default($routeDefinition)

--- a/src/Lit/Router/FastRoute/FastRouteDefinition.php
+++ b/src/Lit/Router/FastRoute/FastRouteDefinition.php
@@ -6,6 +6,9 @@ namespace Lit\Router\FastRoute;
 
 use FastRoute\RouteCollector;
 
+/**
+ * Base class for a invokable object which can be used as route definition.
+ */
 abstract class FastRouteDefinition
 {
     abstract public function __invoke(RouteCollector $routeCollector): void;

--- a/src/Lit/Router/FastRoute/FastRouteRouter.php
+++ b/src/Lit/Router/FastRoute/FastRouteRouter.php
@@ -13,6 +13,9 @@ use Lit\Voltage\Interfaces\RouterStubResolverInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Router use FastRoute to locate stub.
+ */
 class FastRouteRouter extends AbstractRouter
 {
     /**

--- a/src/Lit/Runner/ZendSapi/BoltZendConfiguration.php
+++ b/src/Lit/Runner/ZendSapi/BoltZendConfiguration.php
@@ -12,6 +12,9 @@ use Zend\Diactoros\ServerRequestFactory;
 use Zend\HttpHandlerRunner\Emitter\SapiEmitter;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
+/**
+ * Configuration for zend runner
+ */
 class BoltZendConfiguration
 {
     public static function default()

--- a/src/Lit/Runner/ZendSapi/BoltZendRunner.php
+++ b/src/Lit/Runner/ZendSapi/BoltZendRunner.php
@@ -8,6 +8,9 @@ use Lit\Bolt\BoltContainerConfiguration;
 use Psr\Container\ContainerInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
+/**
+ * App runner using zend HttpHandlerRunner
+ */
 class BoltZendRunner
 {
     public static function run($config = [])

--- a/src/Lit/Voltage/AbstractAction.php
+++ b/src/Lit/Voltage/AbstractAction.php
@@ -9,6 +9,11 @@ use Lit\Voltage\Interfaces\ViewInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Base class for actions.
+ *
+ * It's strongly recommended to have your own action base class extending this one
+ */
 abstract class AbstractAction extends AbstractHandler
 {
     /**
@@ -17,8 +22,11 @@ abstract class AbstractAction extends AbstractHandler
     protected $responseFactory;
 
     /**
-     * @param ResponseInterface $response
-     * @throws ThrowableResponse
+     * Halt execution and return the given response.
+     *
+     * @param ResponseInterface $response The response to be thrown.
+     * @throws ThrowableResponse Throws a standard exception containing given response.
+     * @return void
      */
     protected static function throwResponse(ResponseInterface $response): void
     {
@@ -26,7 +34,7 @@ abstract class AbstractAction extends AbstractHandler
     }
 
     /**
-     * @param ViewInterface $view
+     * @param ViewInterface $view The view instance to be used with this action.
      * @return ViewInterface
      */
     protected function attachView(ViewInterface $view)
@@ -36,6 +44,9 @@ abstract class AbstractAction extends AbstractHandler
         return $view;
     }
 
+    /**
+     * @return JsonView
+     */
     protected function json(): JsonView
     {
         /** @var JsonView $view */

--- a/src/Lit/Voltage/AbstractRouter.php
+++ b/src/Lit/Voltage/AbstractRouter.php
@@ -22,7 +22,7 @@ abstract class AbstractRouter implements RouterInterface
 
     /**
      * @param RouterStubResolverInterface $stubResolver
-     * @param RequestHandlerInterface $notFound
+     * @param RequestHandlerInterface     $notFound
      */
     public function __construct(RouterStubResolverInterface $stubResolver, $notFound = null)
     {

--- a/src/Lit/Voltage/AbstractRouter.php
+++ b/src/Lit/Voltage/AbstractRouter.php
@@ -9,6 +9,9 @@ use Lit\Voltage\Interfaces\RouterStubResolverInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Base class for a typical router implementation
+ */
 abstract class AbstractRouter implements RouterInterface
 {
     /**
@@ -21,8 +24,8 @@ abstract class AbstractRouter implements RouterInterface
     protected $stubResolver;
 
     /**
-     * @param RouterStubResolverInterface $stubResolver
-     * @param RequestHandlerInterface     $notFound
+     * @param RouterStubResolverInterface $stubResolver The stub resolver.
+     * @param mixed                       $notFound     Stub to be used when no stub is found.
      */
     public function __construct(RouterStubResolverInterface $stubResolver, $notFound = null)
     {
@@ -38,7 +41,9 @@ abstract class AbstractRouter implements RouterInterface
     }
 
     /**
-     * @param ServerRequestInterface $request
+     * Find a stub for incoming request. The stub will later be resolved by $this->stubResolver
+     *
+     * @param ServerRequestInterface $request The incoming request.
      * @return mixed
      */
     abstract protected function findStub(ServerRequestInterface $request);
@@ -48,13 +53,20 @@ abstract class AbstractRouter implements RouterInterface
         return $this->stubResolver->resolve($stub);
     }
 
+    /**
+     * Create a request handler with this router.
+     *
+     * @return RequestHandlerInterface
+     */
     public function makeDispatcher(): RequestHandlerInterface
     {
         return new RouterDispatchHandler($this);
     }
 
     /**
-     * @param string $path
+     * Prepend slash to a path if there isn't leading slash
+     *
+     * @param string $path The uri path.
      * @return string
      */
     public static function autoPrependSlash(string $path): string

--- a/src/Lit/Voltage/AbstractView.php
+++ b/src/Lit/Voltage/AbstractView.php
@@ -7,6 +7,9 @@ namespace Lit\Voltage;
 use Lit\Voltage\Interfaces\ViewInterface;
 use Lit\Voltage\Traits\ViewTrait;
 
+/**
+ * Base class for standard view implementations.
+ */
 abstract class AbstractView implements ViewInterface
 {
     use ViewTrait;

--- a/src/Lit/Voltage/App.php
+++ b/src/Lit/Voltage/App.php
@@ -11,6 +11,9 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * App is a complete PSR-15 application, including a middleware pipe and a concrete business handler.
+ */
 class App extends AbstractHandler
 {
     /**
@@ -22,6 +25,13 @@ class App extends AbstractHandler
      */
     protected $businessLogicHandler;
 
+    /**
+     * App constructor
+     *
+     * @param RequestHandlerInterface  $businessLogicHandler The concrete request handler.
+     * @param MiddlewareInterface|null $middleware           Optional. A middleware pipe will be created if this is not
+     *                                                       instance of MiddlewarePipe.
+     */
     public function __construct(RequestHandlerInterface $businessLogicHandler, MiddlewareInterface $middleware = null)
     {
         $this->businessLogicHandler = $businessLogicHandler;
@@ -31,6 +41,8 @@ class App extends AbstractHandler
     }
 
     /**
+     * Getter for middleware pipe
+     *
      * @return MiddlewarePipe
      */
     public function getMiddlewarePipe(): MiddlewarePipe
@@ -38,6 +50,9 @@ class App extends AbstractHandler
         return $this->middlewarePipe;
     }
 
+    /**
+     * @return ResponseInterface
+     */
     protected function main(): ResponseInterface
     {
         try {

--- a/src/Lit/Voltage/BasicRouter.php
+++ b/src/Lit/Voltage/BasicRouter.php
@@ -16,8 +16,8 @@ class BasicRouter extends AbstractRouter
 
     /**
      * @param RouterStubResolverInterface $stubResolver
-     * @param mixed $notFound stub for notFoundMiddleware
-     * @param mixed $methodNotAllowed stub for methodNotAllowedMiddleware
+     * @param mixed                       $notFound         stub for notFoundMiddleware
+     * @param mixed                       $methodNotAllowed stub for methodNotAllowedMiddleware
      */
     public function __construct(RouterStubResolverInterface $stubResolver, $notFound = null, $methodNotAllowed = null)
     {

--- a/src/Lit/Voltage/BasicRouter.php
+++ b/src/Lit/Voltage/BasicRouter.php
@@ -7,6 +7,9 @@ namespace Lit\Voltage;
 use Lit\Voltage\Interfaces\RouterStubResolverInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * Basic router implementation that do strict match against method & path
+ */
 class BasicRouter extends AbstractRouter
 {
     protected $mounts = [];
@@ -15,9 +18,9 @@ class BasicRouter extends AbstractRouter
     protected $methodNotAllowed;
 
     /**
-     * @param RouterStubResolverInterface $stubResolver
-     * @param mixed                       $notFound         stub for notFoundMiddleware
-     * @param mixed                       $methodNotAllowed stub for methodNotAllowedMiddleware
+     * @param RouterStubResolverInterface $stubResolver     The stub resolver.
+     * @param mixed                       $notFound         Stub when route is not found.
+     * @param mixed                       $methodNotAllowed Stub when route exists but method is mismatch.
      */
     public function __construct(RouterStubResolverInterface $stubResolver, $notFound = null, $methodNotAllowed = null)
     {
@@ -43,32 +46,78 @@ class BasicRouter extends AbstractRouter
         }
     }
 
+    /**
+     * Register a route
+     *
+     * @param string $method    The HTTP method.
+     * @param string $path      The full URI path.
+     * @param mixed  $routeStub The route.
+     * @return $this
+     */
     public function register(string $method, string $path, $routeStub): BasicRouter
     {
         $this->routes[$path][strtolower($method)] = $routeStub;
         return $this;
     }
 
+    /**
+     * Register a GET route
+     *
+     * @param string $path      The full URI path.
+     * @param mixed  $routeStub The route.
+     * @return $this
+     */
     public function get(string $path, $routeStub): BasicRouter
     {
         return $this->register('get', $path, $routeStub);
     }
 
+
+    /**
+     * Register a POST route
+     *
+     * @param string $path      The full URI path.
+     * @param mixed  $routeStub The route.
+     * @return $this
+     */
     public function post(string $path, $routeStub): BasicRouter
     {
         return $this->register('post', $path, $routeStub);
     }
 
+
+    /**
+     * Register a PUT route
+     *
+     * @param string $path      The full URI path.
+     * @param mixed  $routeStub The route.
+     * @return $this
+     */
     public function put(string $path, $routeStub): BasicRouter
     {
         return $this->register('put', $path, $routeStub);
     }
 
+
+    /**
+     * Register a DELETE route
+     *
+     * @param string $path      The full URI path.
+     * @param mixed  $routeStub The route.
+     * @return $this
+     */
     public function delete(string $path, $routeStub): BasicRouter
     {
         return $this->register('delete', $path, $routeStub);
     }
 
+    /**
+     * Register a PATCH route
+     *
+     * @param string $path      The full URI path.
+     * @param mixed  $routeStub The route.
+     * @return $this
+     */
     public function patch(string $path, $routeStub): BasicRouter
     {
         return $this->register('patch', $path, $routeStub);

--- a/src/Lit/Voltage/Interfaces/RouterInterface.php
+++ b/src/Lit/Voltage/Interfaces/RouterInterface.php
@@ -7,13 +7,15 @@ namespace Lit\Voltage\Interfaces;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Standard interface for http router
+ */
 interface RouterInterface
 {
-
     /**
-     * Find the corresponding RequestHandler according to the input $request
+     * Find the corresponding RequestHandler according to the request
      *
-     * @param ServerRequestInterface $request
+     * @param ServerRequestInterface $request The incoming request.
      * @return RequestHandlerInterface
      */
     public function route(ServerRequestInterface $request): RequestHandlerInterface;

--- a/src/Lit/Voltage/Interfaces/RouterStubResolverInterface.php
+++ b/src/Lit/Voltage/Interfaces/RouterStubResolverInterface.php
@@ -6,12 +6,15 @@ namespace Lit\Voltage\Interfaces;
 
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Interface for a stub resolver used with router
+ */
 interface RouterStubResolverInterface
 {
     /**
      * Resolve the stub and return a RequestHandler
      *
-     * @param mixed $stub
+     * @param mixed $stub The stub value to be resolved.
      * @return RequestHandlerInterface
      */
     public function resolve($stub): RequestHandlerInterface;

--- a/src/Lit/Voltage/Interfaces/ThrowableResponseInterface.php
+++ b/src/Lit/Voltage/Interfaces/ThrowableResponseInterface.php
@@ -6,7 +6,14 @@ namespace Lit\Voltage\Interfaces;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Interface for a throwable response (exception that contains a response)
+ */
 interface ThrowableResponseInterface
 {
+    /**
+     * Getter for the inside response
+     * @return ResponseInterface
+     */
     public function getResponse(): ResponseInterface;
 }

--- a/src/Lit/Voltage/Interfaces/ViewInterface.php
+++ b/src/Lit/Voltage/Interfaces/ViewInterface.php
@@ -6,12 +6,15 @@ namespace Lit\Voltage\Interfaces;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Interface for view class
+ */
 interface ViewInterface
 {
     /**
      * Render the response using $data
      *
-     * @param array $data
+     * @param array $data Data to be rendered.
      * @return ResponseInterface
      */
     public function render(array $data = []): ResponseInterface;
@@ -19,7 +22,8 @@ interface ViewInterface
     /**
      * Accept the response prototype
      *
-     * @param ResponseInterface $response
+     * @param ResponseInterface $response The PSR response prototype.
+     * @return void
      */
     public function setResponse(ResponseInterface $response): void;
 }

--- a/src/Lit/Voltage/JsonView.php
+++ b/src/Lit/Voltage/JsonView.php
@@ -33,7 +33,7 @@ class JsonView extends AbstractView
     }
 
     /**
-     * @return int
+     * @return integer
      */
     public function getJsonOption()
     {
@@ -42,7 +42,7 @@ class JsonView extends AbstractView
 
     /**
      *
-     * @param int $jsonOption
+     * @param integer $jsonOption
      * @return $this
      */
     public function setJsonOption($jsonOption)

--- a/src/Lit/Voltage/JsonView.php
+++ b/src/Lit/Voltage/JsonView.php
@@ -6,13 +6,20 @@ namespace Lit\Voltage;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * A simple view class doing json_encode for payloads.
+ */
 class JsonView extends AbstractView
 {
     const JSON_ROOT = self::class;
     protected $jsonOption = 0;
 
     /**
-     * @param array $data
+     * {@inheritDoc}
+     *
+     * You may use renderJson which receive any type instead of this.
+     *
+     * @param array $data Payload. If JsonView::JSON_ROOT exist in payload, it will be used instead of whole payload.
      * @return ResponseInterface
      */
     public function render(array $data = []): ResponseInterface
@@ -27,6 +34,12 @@ class JsonView extends AbstractView
             ->withHeader('Content-Type', 'application/json');
     }
 
+    /**
+     * Render method that receives any type of payload.
+     *
+     * @param mixed $value The payload to be outputed.
+     * @return ResponseInterface
+     */
     public function renderJson($value): ResponseInterface
     {
         return $this->render([static::JSON_ROOT => $value]);
@@ -35,20 +48,18 @@ class JsonView extends AbstractView
     /**
      * @return integer
      */
-    public function getJsonOption()
+    public function getJsonOption(): int
     {
         return $this->jsonOption;
     }
 
     /**
-     *
-     * @param integer $jsonOption
+     * @param integer $jsonOption The new json option.
      * @return $this
      */
-    public function setJsonOption($jsonOption)
+    public function setJsonOption(int $jsonOption)
     {
         $this->jsonOption = $jsonOption;
-
         return $this;
     }
 }

--- a/src/Lit/Voltage/RouteStubResolver.php
+++ b/src/Lit/Voltage/RouteStubResolver.php
@@ -7,8 +7,15 @@ namespace Lit\Voltage;
 use Lit\Voltage\Interfaces\RouterStubResolverInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
+/**
+ * Basic router stub resolver that do nothing but just use stub itself as request handler.
+ */
 class RouteStubResolver implements RouterStubResolverInterface
 {
+    /**
+     * @param mixed $stub The stub value to be resolved.
+     * @return RequestHandlerInterface
+     */
     public function resolve($stub): RequestHandlerInterface
     {
         return $stub;

--- a/src/Lit/Voltage/RouterDispatchHandler.php
+++ b/src/Lit/Voltage/RouterDispatchHandler.php
@@ -8,6 +8,9 @@ use Lit\Nimo\Handlers\AbstractHandler;
 use Lit\Voltage\Interfaces\RouterInterface;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Handle request with embeded router
+ */
 class RouterDispatchHandler extends AbstractHandler
 {
     /**
@@ -16,13 +19,16 @@ class RouterDispatchHandler extends AbstractHandler
     protected $router;
 
     /**
-     * @param RouterInterface $router
+     * @param RouterInterface $router Router instance to be used.
      */
     public function __construct(RouterInterface $router)
     {
         $this->router = $router;
     }
 
+    /**
+     * @return ResponseInterface
+     */
     protected function main(): ResponseInterface
     {
         $action = $this->router->route($this->request);

--- a/src/Lit/Voltage/Tests/JsonViewTest.php
+++ b/src/Lit/Voltage/Tests/JsonViewTest.php
@@ -62,8 +62,8 @@ class JsonViewTest extends TestCase
 
 
     /**
-     * @param array $renderData
-     * @param string|bool $expectedBodyContent
+     * @param array          $renderData
+     * @param string|boolean $expectedBodyContent
      */
     protected function assertRenderAsExpected(array $renderData, $expectedBodyContent): void
     {

--- a/src/Lit/Voltage/ThrowableResponse.php
+++ b/src/Lit/Voltage/ThrowableResponse.php
@@ -8,6 +8,9 @@ use Lit\Voltage\Interfaces\ThrowableResponseInterface;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
+/**
+ * Standard custom exception which contains a response.
+ */
 class ThrowableResponse extends \Exception implements ThrowableResponseInterface
 {
     /**
@@ -15,20 +18,33 @@ class ThrowableResponse extends \Exception implements ThrowableResponseInterface
      */
     protected $response;
 
-    public function __construct(ResponseInterface $response, Throwable $previous = null, $message = "", $code = 0)
-    {
+    /**
+     * @param ResponseInterface $response The response to include in the exception.
+     * @param Throwable|null    $previous The previous throwable used for the exception chaining.
+     * @param string            $message  The Exception message to throw.
+     * @param integer           $code     The Exception code.
+     */
+    public function __construct(
+        ResponseInterface $response,
+        Throwable $previous = null,
+        string $message = "",
+        int $code = 0
+    ) {
         parent::__construct($message, $code, $previous);
         $this->response = $response;
     }
 
+    /**
+     * Create a ThrowableResponse with no other exception information
+     *
+     * @param ResponseInterface $response The response.
+     * @return ThrowableResponse
+     */
     public static function of(ResponseInterface $response)
     {
         return new static($response);
     }
 
-    /**
-     * @return ResponseInterface
-     */
     public function getResponse(): ResponseInterface
     {
         return $this->response;

--- a/src/Lit/Voltage/Traits/ViewTrait.php
+++ b/src/Lit/Voltage/Traits/ViewTrait.php
@@ -6,6 +6,9 @@ namespace Lit\Voltage\Traits;
 
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * Implements ViewInterface and provide a helper method getEmptyBody.
+ */
 trait ViewTrait
 {
     /**
@@ -14,8 +17,9 @@ trait ViewTrait
     protected $response;
 
     /**
-     *
-     * @param ResponseInterface $response
+     * @ses \Lit\Voltage\Interfaces\ViewInterface::setResponse
+     * @param ResponseInterface $response Set the response prototype.
+     * @return void
      */
     public function setResponse(ResponseInterface $response): void
     {
@@ -23,10 +27,10 @@ trait ViewTrait
     }
 
     /**
-     * ensure body is empty and writable and return that
+     * Ensure body is empty and writable and return that.
      *
      * @return \Psr\Http\Message\StreamInterface
-     * @throws \RuntimeException
+     * @throws \RuntimeException When the body is not writable or not empty somehow.
      */
     protected function getEmptyBody()
     {


### PR DESCRIPTION
Fix #2 

- [BC] Some method signature are changed (mostly adding types), should not affect anyone unless he subclass and override any of them.
  + CachedDispatcher::__construct
  + SlicedValue::__construct
  + Factory::inject becomes protected
  + Factory::resolveParam
  + Factory::set
  + JsonView::setJsonOption
