### PR TITLE
[Feature] Expose setter injection failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+## next (v0.9.2)
+- [#9](https://github.com/litphp/litphp/pull/9) air: container exception happened during setter injection is no longer ignored
+
 ## v0.9.1
 
 ### Changes

--- a/src/Lit/Air/Injection/SetterInjector.php
+++ b/src/Lit/Air/Injection/SetterInjector.php
@@ -41,12 +41,8 @@ class SetterInjector implements InjectorInterface
                 $keys[] = $paramClassName = $paramClass->name;
             }
 
-            try {
-                $value = $factory->resolveDependency($class->name, $keys, $paramClassName, $extra);
-                $method->invoke($obj, $value);
-            } catch (ContainerException $e) {
-                //ignore
-            }
+            $value = $factory->resolveDependency($class->name, $keys, $paramClassName, $extra);
+            $method->invoke($obj, $value);
         }
     }
 

--- a/src/Lit/Air/Injection/SetterInjector.php
+++ b/src/Lit/Air/Injection/SetterInjector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lit\Air\Injection;
 
 use Lit\Air\Factory;
-use Lit\Air\Psr\ContainerException;
 use ReflectionMethod;
 
 /**


### PR DESCRIPTION
`ContainerException` thrown during resolving dependency in setter injection was silently ignored.

We now unmute this exception so configuration error can be fixed with less efforts