### PR TITLE
[Feature] Air refactor

### DIFF
--- a/src/Lit/Air/Configurator.php
+++ b/src/Lit/Air/Configurator.php
@@ -287,7 +287,7 @@ class Configurator
      * @param RecipeInterface $recipe     The decorated recipe instance.
      * @return RecipeInterface
      */
-    public static function wrapRecipeWithDecorators(array $decorators, RecipeInterface $recipe): RecipeInterface
+    protected static function wrapRecipeWithDecorators(array $decorators, RecipeInterface $recipe): RecipeInterface
     {
         foreach ($decorators as $name => $option) {
             if (isset(self::$decorators[$name])) {

--- a/src/Lit/Air/Configurator.php
+++ b/src/Lit/Air/Configurator.php
@@ -6,6 +6,7 @@ namespace Lit\Air;
 
 use Lit\Air\Psr\Container;
 use Lit\Air\Psr\ContainerException;
+use Lit\Air\Recipe\AbstractRecipe;
 use Lit\Air\Recipe\AutowireRecipe;
 use Lit\Air\Recipe\BuilderRecipe;
 use Lit\Air\Recipe\Decorator\AbstractRecipeDecorator;
@@ -68,7 +69,7 @@ class Configurator
             trigger_error("array should be wrapped with C::value", E_USER_NOTICE);
         }
 
-        return Container::value($value);
+        return AbstractRecipe::value($value);
     }
 
     /**
@@ -262,12 +263,12 @@ class Configurator
             $valueDecorator = $arr['decorator'] ?? null;
             unset($arr['decorator']);
 
-            $builder = [Container::class, $type];
+            $builder = [AbstractRecipe::class, $type];
             assert(is_callable($builder));
             /**
              * @var RecipeInterface $recipe
              */
-            $recipe = call_user_func_array($builder, $arr);
+            $recipe = $builder(...$arr);
 
             if ($valueDecorator) {
                 $recipe = self::wrapRecipeWithDecorators($valueDecorator, $recipe);

--- a/src/Lit/Air/Factory.php
+++ b/src/Lit/Air/Factory.php
@@ -109,7 +109,7 @@ class Factory
         }
 
         assert(is_callable($callback));
-        return call_user_func_array($callback, $this->resolveParams($params, '!' . $name, $extra));
+        return $callback(...$this->resolveParams($params, '!' . $name, $extra));
     }
 
     /**

--- a/src/Lit/Air/Factory.php
+++ b/src/Lit/Air/Factory.php
@@ -16,7 +16,7 @@ use Psr\Container\ContainerInterface;
 class Factory
 {
     public const CONTAINER_KEY = self::class;
-    public const CONFIG_INJECTORS = self::class . '::injectors';
+    public const INJECTOR = self::class . '::injector';
     /**
      * @var Container
      */
@@ -149,17 +149,15 @@ class Factory
      */
     protected function inject($obj, array $extra = []): void
     {
-        if (!$this->container->has(static::CONFIG_INJECTORS)) {
+        if (!$this->container->has(static::INJECTOR)) {
             return;
         }
-        foreach ($this->container->get(static::CONFIG_INJECTORS) as $injector) {
-            /**
-             * @var InjectorInterface $injector
-             */
-            if ($injector->isTarget($obj)) {
-                $injector->inject($this, $obj, $extra);
-            }
-        }
+
+        /**
+         * @var InjectorInterface $injector
+         */
+        $injector = $this->container->get(static::INJECTOR);
+        $injector->inject($this, $obj, $extra);
     }
 
     /**
@@ -189,26 +187,6 @@ class Factory
         }
 
         throw new ContainerException('failed to produce dependency for ' . $consumer);
-    }
-
-    /**
-     * Register a injector.
-     *
-     * @param InjectorInterface $injector The injector.
-     * @return Factory
-     */
-    public function addInjector(InjectorInterface $injector): self
-    {
-        if (!$this->container->has(static::CONFIG_INJECTORS)) {
-            $this->container->set(static::CONFIG_INJECTORS, [$injector]);
-        } else {
-            $this->container->set(
-                static::CONFIG_INJECTORS,
-                array_merge($this->container->get(static::CONFIG_INJECTORS), [$injector])
-            );
-        }
-
-        return $this;
     }
 
     /**

--- a/src/Lit/Air/Injection/InjectorInterface.php
+++ b/src/Lit/Air/Injection/InjectorInterface.php
@@ -12,14 +12,6 @@ use Lit\Air\Factory;
 interface InjectorInterface
 {
     /**
-     * Decide whether provided object is target of this injector.
-     *
-     * @param object $obj The object to be checked.
-     * @return boolean
-     */
-    public function isTarget($obj): bool;
-
-    /**
      * Do the injection process.
      *
      * @param Factory $factory The factory.

--- a/src/Lit/Air/Injection/SetterInjector.php
+++ b/src/Lit/Air/Injection/SetterInjector.php
@@ -28,6 +28,10 @@ class SetterInjector implements InjectorInterface
 
     public function inject(Factory $factory, $obj, array $extra = []): void
     {
+        if (!$this->isTarget($obj)) {
+            return;
+        }
+
         $class = new \ReflectionClass($obj);
         foreach ($class->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             if (!$this->shouldBeInjected($method)) {
@@ -46,7 +50,7 @@ class SetterInjector implements InjectorInterface
         }
     }
 
-    public function isTarget($obj): bool
+    protected function isTarget($obj): bool
     {
         $class = get_class($obj);
         return defined("$class::SETTER_INJECTOR") && $class::SETTER_INJECTOR === static::class;
@@ -86,9 +90,7 @@ class SetterInjector implements InjectorInterface
     public static function configuration()
     {
         return [
-            Factory::CONFIG_INJECTORS => C::value([
-                new SetterInjector(),
-            ]),
+            Factory::INJECTOR => C::value(new SetterInjector()),
         ];
     }
 }

--- a/src/Lit/Air/Injection/SetterInjector.php
+++ b/src/Lit/Air/Injection/SetterInjector.php
@@ -86,7 +86,7 @@ class SetterInjector implements InjectorInterface
     public static function configuration()
     {
         return [
-            Factory::KEY_INJECTORS => C::value([
+            Factory::CONFIG_INJECTORS => C::value([
                 new SetterInjector(),
             ]),
         ];

--- a/src/Lit/Air/Psr/Container.php
+++ b/src/Lit/Air/Psr/Container.php
@@ -6,11 +6,6 @@ namespace Lit\Air\Psr;
 
 use Lit\Air\Configurator;
 use Lit\Air\Recipe\AbstractRecipe;
-use Lit\Air\Recipe\AliasRecipe;
-use Lit\Air\Recipe\AutowireRecipe;
-use Lit\Air\Recipe\BuilderRecipe;
-use Lit\Air\Recipe\FixedValueRecipe;
-use Lit\Air\Recipe\InstanceRecipe;
 use Lit\Air\Recipe\RecipeInterface;
 use Psr\Container\ContainerInterface;
 
@@ -51,65 +46,6 @@ class Container implements ContainerInterface
     }
 
     /**
-     * Create a alias
-     *
-     * @param string $alias The alias string key.
-     * @return AbstractRecipe
-     */
-    public static function alias(string $alias): AbstractRecipe
-    {
-        return new AliasRecipe($alias);
-    }
-
-    /**
-     * Autowire this entry
-     *
-     * @param string $className The Classname.
-     * @param array  $extra     Extra parameteres.
-     * @param bool   $cached    Whether to save the instance if it's not defined in container.
-     * @return AbstractRecipe
-     */
-    public static function autowire(string $className, array $extra = [], bool $cached = true): AbstractRecipe
-    {
-        return new AutowireRecipe($className, $extra, $cached);
-    }
-
-    /**
-     * Populate an instance by factory
-     *
-     * @param string|null $className Optional classname. Can be ommited when the entry key is the classname.
-     * @param array       $extra     Extra parameteres.
-     * @return AbstractRecipe
-     */
-    public static function instance(?string $className = null, array $extra = []): AbstractRecipe
-    {
-        return new InstanceRecipe($className, $extra);
-    }
-
-    /**
-     * Calls a builder method using factory.
-     *
-     * @param callable $builder The builder method. Its parameter will be injected as dependency.
-     * @param array    $extra   Extra parameters.
-     * @return AbstractRecipe
-     */
-    public static function builder(callable $builder, array $extra = []): AbstractRecipe
-    {
-        return new BuilderRecipe($builder, $extra);
-    }
-
-    /**
-     * A fixed value
-     *
-     * @param mixed $value The value.
-     * @return AbstractRecipe
-     */
-    public static function value($value): AbstractRecipe
-    {
-        return new FixedValueRecipe($value);
-    }
-
-    /**
      * Wraps a PSR container
      *
      * @param ContainerInterface $container The container.
@@ -119,6 +55,7 @@ class Container implements ContainerInterface
     {
         return (new static())->setDelegateContainer($container);
     }
+
 
     public function get($id)
     {
@@ -168,7 +105,7 @@ class Container implements ContainerInterface
      */
     public function provideParameter(string $className, array $extra = [], bool $cached = true)
     {
-        return $this->define($className, self::autowire($className, $extra, $cached));
+        return $this->define($className, AbstractRecipe::autowire($className, $extra, $cached));
     }
 
     /**

--- a/src/Lit/Air/Recipe/AbstractRecipe.php
+++ b/src/Lit/Air/Recipe/AbstractRecipe.php
@@ -10,4 +10,63 @@ namespace Lit\Air\Recipe;
 abstract class AbstractRecipe implements RecipeInterface
 {
     use RecipeTrait;
+
+    /**
+     * A fixed value
+     *
+     * @param mixed $value The value.
+     * @return AbstractRecipe
+     */
+    public static function value($value): AbstractRecipe
+    {
+        return new FixedValueRecipe($value);
+    }
+
+    /**
+     * Create a alias
+     *
+     * @param string $alias The alias string key.
+     * @return AbstractRecipe
+     */
+    public static function alias(string $alias): AbstractRecipe
+    {
+        return new AliasRecipe($alias);
+    }
+
+    /**
+     * Calls a builder method using factory.
+     *
+     * @param callable $builder The builder method. Its parameter will be injected as dependency.
+     * @param array    $extra   Extra parameters.
+     * @return AbstractRecipe
+     */
+    public static function builder(callable $builder, array $extra = []): AbstractRecipe
+    {
+        return new BuilderRecipe($builder, $extra);
+    }
+
+    /**
+     * Populate an instance by factory
+     *
+     * @param string|null $className Optional classname. Can be ommited when the entry key is the classname.
+     * @param array       $extra     Extra parameteres.
+     * @return AbstractRecipe
+     */
+    public static function instance(?string $className = null, array $extra = []): AbstractRecipe
+    {
+        return new InstanceRecipe($className, $extra);
+    }
+
+    /**
+     * Autowire this entry
+     *
+     * @param string $className The Classname.
+     * @param array  $extra     Extra parameteres.
+     * @param bool   $cached    Whether to save the instance if it's not defined in container.
+     * @return AbstractRecipe
+     */
+    public static function autowire(string $className, array $extra = [], bool $cached = true): AbstractRecipe
+    {
+        return new AutowireRecipe($className, $extra, $cached);
+    }
 }

--- a/src/Lit/Air/Recipe/InstanceRecipe.php
+++ b/src/Lit/Air/Recipe/InstanceRecipe.php
@@ -35,7 +35,7 @@ class InstanceRecipe extends AbstractRecipe
     {
         $className = $this->className;
         if ($className === null || !class_exists($className)) {
-            throw new ContainerException('unknown autowire class name');
+            throw new ContainerException('unknown class name');
         }
 
         return Factory::of($container)->instantiate(

--- a/src/Lit/Air/Tests/AliasRecipeTest.php
+++ b/src/Lit/Air/Tests/AliasRecipeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Lit\Air\Tests;
 
 use Lit\Air\Factory;
-use Lit\Air\Psr\Container;
+use Lit\Air\Recipe\AbstractRecipe;
 
 class AliasRecipeTest extends AirTestCase
 {
@@ -19,8 +19,8 @@ class AliasRecipeTest extends AirTestCase
 
         $this->container
             ->set($key, $obj)
-            ->define($key2, Container::alias($key))
-            ->define($key3, Container::alias(\stdClass::class));
+            ->define($key2, AbstractRecipe::alias($key))
+            ->define($key3, AbstractRecipe::alias(\stdClass::class));
 
         $this->assertKeyExistWithValue($key2, $obj);
         $this->assertKeyExistWithValue($key3, $obj2);

--- a/src/Lit/Air/Tests/AutowireRecipeTest.php
+++ b/src/Lit/Air/Tests/AutowireRecipeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lit\Air\Tests;
 
+use Lit\Air\Factory;
 use Lit\Air\Injection\SetterInjector;
 use Lit\Air\Recipe\AbstractRecipe;
 use Lit\Air\Recipe\AutowireRecipe;
@@ -30,7 +31,7 @@ class AutowireRecipeTest extends AirTestCase
         self::assertEquals(null, $instance->getSplObjectStorage());
 
         $key2 = self::randKey();
-        $this->getFactory()->addInjector(new SetterInjector());
+        $this->container->set(Factory::INJECTOR, new SetterInjector());
         $this->container->define($key2, AbstractRecipe::instance(Foo::class, [
             'bar' => $obj,
         ]));

--- a/src/Lit/Air/Tests/AutowireRecipeTest.php
+++ b/src/Lit/Air/Tests/AutowireRecipeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Lit\Air\Tests;
 
 use Lit\Air\Injection\SetterInjector;
-use Lit\Air\Psr\Container;
+use Lit\Air\Recipe\AbstractRecipe;
 use Lit\Air\Recipe\AutowireRecipe;
 
 class AutowireRecipeTest extends AirTestCase
@@ -14,7 +14,7 @@ class AutowireRecipeTest extends AirTestCase
     {
         $key = self::randKey();
         $obj = new \stdClass();
-        $recipe = Container::autowire(Foo::class, [
+        $recipe = AbstractRecipe::autowire(Foo::class, [
             'bar' => $obj,
         ]);
         $this->assertInstanceOf(AutowireRecipe::class, $recipe);
@@ -31,7 +31,7 @@ class AutowireRecipeTest extends AirTestCase
 
         $key2 = self::randKey();
         $this->getFactory()->addInjector(new SetterInjector());
-        $this->container->define($key2, Container::instance(Foo::class, [
+        $this->container->define($key2, AbstractRecipe::instance(Foo::class, [
             'bar' => $obj,
         ]));
         $instance = $this->container->get($key2);

--- a/src/Lit/Air/Tests/BuilderRecipeTest.php
+++ b/src/Lit/Air/Tests/BuilderRecipeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Lit\Air\Tests;
 
-use Lit\Air\Psr\Container;
+use Lit\Air\Recipe\AbstractRecipe;
 use Lit\Air\Recipe\BuilderRecipe;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -26,7 +26,7 @@ class BuilderRecipeTest extends AirTestCase
 
         /** @var callable $builder */
         $builder = [$mock, 'factory'];
-        $stub = Container::builder($builder);
+        $stub = AbstractRecipe::builder($builder);
 
         self::assertTrue($stub instanceof BuilderRecipe);
 

--- a/src/Lit/Air/Tests/FactoryTest.php
+++ b/src/Lit/Air/Tests/FactoryTest.php
@@ -7,8 +7,8 @@ namespace Lit\Air\Tests;
 use Lit\Air\Configurator as C;
 use Lit\Air\Factory;
 use Lit\Air\Psr\CircularDependencyException;
-use Lit\Air\Psr\Container;
 use Lit\Air\Psr\ContainerException;
+use Lit\Air\Recipe\AbstractRecipe;
 use Psr\Container\ContainerInterface;
 
 class FactoryTest extends AirTestCase
@@ -84,7 +84,7 @@ class FactoryTest extends AirTestCase
         self::assertSame(42, $returnValue);
 
 
-        $this->container->define(ContainerInterface::class, Container::value($this->container));
+        $this->container->define(ContainerInterface::class, AbstractRecipe::value($this->container));
         $returnValue = $this->factory->invoke(function (ContainerInterface $foo) {
             return $foo;
         });
@@ -151,9 +151,9 @@ class FactoryTest extends AirTestCase
     {
         self::assertEquals(2, 1 + 1);
         try {
-            $this->container->define(\ArrayObject::class, Container::builder([$this, 'circularFoo']))
-                ->define(Foo::class, Container::autowire(Foo::class, [
-                    'bar' => Container::builder(function (\ArrayObject $object) {
+            $this->container->define(\ArrayObject::class, AbstractRecipe::builder([$this, 'circularFoo']))
+                ->define(Foo::class, AbstractRecipe::autowire(Foo::class, [
+                    'bar' => AbstractRecipe::builder(function (\ArrayObject $object) {
                         return get_class($object);
                     }),
                 ]));

--- a/src/Lit/Air/Tests/FixedValueRecipeTest.php
+++ b/src/Lit/Air/Tests/FixedValueRecipeTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Lit\Air\Tests;
 
-use Lit\Air\Psr\Container;
+use Lit\Air\Recipe\AbstractRecipe;
 use Lit\Air\Recipe\FixedValueRecipe;
 
 class FixedValueRecipeTest extends AirTestCase
@@ -13,7 +13,7 @@ class FixedValueRecipeTest extends AirTestCase
     {
         $key = self::randKey();
         $obj = new \stdClass();
-        $stub = Container::value($obj);
+        $stub = AbstractRecipe::value($obj);
         self::assertTrue($stub instanceof FixedValueRecipe);
 
         $returnValue = $this->container->define($key, $stub);

--- a/src/Lit/Air/Tests/SingletonDecoratorTest.php
+++ b/src/Lit/Air/Tests/SingletonDecoratorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Lit\Air\Tests;
 
 use Lit\Air\Configurator;
-use Lit\Air\Psr\Container;
+use Lit\Air\Recipe\AbstractRecipe;
 use Lit\Air\Recipe\BuilderRecipe;
 use Lit\Air\Recipe\Decorator\SingletonDecorator;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -44,7 +44,7 @@ class SingletonDecoratorTest extends AirTestCase
         $this->container->get($key2);
 
         //re define the stub affect immediately (the cache is on Stub class, not countainer)
-        $this->container->define($key, Container::value($obj2));
+        $this->container->define($key, AbstractRecipe::value($obj2));
         $this->assertKeyExistWithValue($key, $obj2);
     }
 

--- a/src/Lit/Bolt/Router/BoltStubResolver.php
+++ b/src/Lit/Bolt/Router/BoltStubResolver.php
@@ -57,7 +57,9 @@ class BoltStubResolver implements RouterStubResolverInterface
             return FixedResponseHandler::wrap($stub);
         }
 
-        $handler = Configurator::convertToRecipe($stub)->resolve($this->container);
+        /** @var Configurator $cfg */
+        $cfg = $this->container::CONFIGURATOR_CLASS;
+        $handler = $cfg::convertToRecipe($stub)->resolve($this->container);
 
         if (!$handler instanceof RequestHandlerInterface) {
             /** @var StubResolveException $exception */


### PR DESCRIPTION
- move recipe builder methods on Container to AbstractRecipe
- remove support for multiple injector instances (user can chain it via interface)
- remove Injector::isTarget method from interface
